### PR TITLE
Add progress bars to ci:watch

### DIFF
--- a/lib/watch-test-runs.js
+++ b/lib/watch-test-runs.js
@@ -1,11 +1,15 @@
 const cli = require('heroku-cli-util')
-const log = require('single-line-log').stdout
 const io = require('socket.io-client')
+const ansiEscapes = require('ansi-escapes')
 const api = require('./heroku-api')
 const TestRun = require('./test-run')
+const wait = require('co-wait')
 
 const SIMI = 'https://simi-production.herokuapp.com'
 const { PENDING, CREATING, BUILDING, RUNNING, ERRORED, FAILED, SUCCEEDED } = TestRun.STATES
+
+// used to pad the status column so that the progress bars align
+const maxStateLength = Math.max.apply(null, Object.keys(TestRun.STATES).map((k) => TestRun.STATES[k]))
 
 const STATUS_ICONS = {
   [PENDING]: '⋯',
@@ -13,7 +17,7 @@ const STATUS_ICONS = {
   [BUILDING]: '⋯',
   [RUNNING]: '⋯',
   [ERRORED]: '!',
-  [FAILED]: '𐄂',
+  [FAILED]: '✗',
   [SUCCEEDED]: '✓'
 }
 
@@ -31,16 +35,8 @@ function isRunningOrRecent (testRun) {
   return TestRun.isNotTerminal(testRun) || TestRun.isRecent(testRun)
 }
 
-function* getRunningTests (heroku, pipelineID) {
-  return (yield api.testRuns(heroku, pipelineID)).filter(isRunningOrRecent)
-}
-
 function statusIcon ({ status }) {
   return cli.color[STATUS_COLORS[status]](STATUS_ICONS[status])
-}
-
-function printLine (testRun) {
-  return `${statusIcon(testRun)} #${testRun.number} ${testRun.commit_branch}:${testRun.commit_sha.slice(0, 6)} ${testRun.status}`
 }
 
 function handleTestRunEvent (newTestRun, testRuns) {
@@ -56,14 +52,22 @@ function handleTestRunEvent (newTestRun, testRuns) {
 }
 
 function render (testRuns) {
-  const sorted = testRuns.sort((a, b) => a.number < b.number ? 1 : -1)
-  log(sorted.map(printLine).join('\n'))
+  process.stdout.write(ansiEscapes.eraseDown)
+
+  const sorted = testRuns.filter(isRunningOrRecent).sort((a, b) => a.number < b.number ? 1 : -1)
+  cli.table(sorted.map((testRun) => columns(testRun, testRuns)), {
+    printHeader: false
+  })
+
+  process.stdout.write(ansiEscapes.cursorUp(sorted.length))
 }
 
 function* watch (pipeline, { heroku }) {
   cli.styledHeader(`Watching test runs for the ${pipeline.name} pipeline`)
 
-  let testRuns = yield getRunningTests(heroku, pipeline.id)
+  let testRuns = yield api.testRuns(heroku, pipeline.id)
+
+  process.stdout.write(ansiEscapes.cursorHide)
 
   render(testRuns)
 
@@ -89,6 +93,43 @@ function* watch (pipeline, { heroku }) {
       render(testRuns)
     }
   })
+
+  // refresh the table every second for progress bar updates
+  while (true) {
+    yield wait(1000)
+    render(testRuns)
+  }
+}
+
+function timeDiff (updatedAt, createdAt) {
+  return (updatedAt.getTime() - createdAt.getTime()) / 1000
+}
+
+function averageTime (testRuns) {
+  return testRuns.map((testRun) => timeDiff(new Date(testRun.updated_at), new Date(testRun.created_at))).reduce((a, b) => a + b, 0) / testRuns.length
+}
+
+function progressBar (testRun, allTestRuns, numBars = 100) {
+  // only include the last X runs which have finished
+  const numRuns = 10
+  const terminalRuns = allTestRuns.filter(TestRun.isTerminal).slice(0, numRuns)
+
+  if (TestRun.isTerminal(testRun) || terminalRuns.length === 0) {
+    return ''
+  }
+
+  const avg = averageTime(terminalRuns)
+  const testRunElapsed = timeDiff(new Date(), new Date(testRun.created_at))
+  const percentageComplete = Math.min(Math.floor((testRunElapsed / avg) * numBars), numBars)
+  return `[${'='.repeat(percentageComplete)}${' '.repeat(numBars - percentageComplete)}]`
+}
+
+function padStatus (testStatus) {
+  return testStatus + ' '.repeat(Math.max(0, maxStateLength - testStatus.length))
+}
+
+function columns (testRun, allTestRuns) {
+  return [statusIcon(testRun), testRun.number, testRun.commit_branch, testRun.commit_sha.slice(0, 6), padStatus(testRun.status), progressBar(testRun, allTestRuns)]
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
     "standard-tap": "^1.0.1"
   },
   "dependencies": {
+    "ansi-escapes": "1.4.0",
     "co": "^4.6.0",
     "co-wait": "0.0.0",
     "github-url-to-object": "^2.2.6",
     "got": "^6.6.3",
     "heroku-cli-util": "^6.0.15",
-    "single-line-log": "^1.1.2",
     "socket.io-client": "^1.5.1",
     "temp": "^0.8.3"
   }


### PR DESCRIPTION
@appleton I added progress bars to ci:watch that refresh every second based off the average `(updated_at - created_at)` of the last ten completed runs.