### PR TITLE
Pass organization when creating tests

### DIFF
--- a/commands/ci/rerun.js
+++ b/commands/ci/rerun.js
@@ -32,6 +32,7 @@ function* run (context, heroku) {
       commit_message: sourceTestRun.commit_message,
       commit_sha: sourceTestRun.commit_sha,
       pipeline: pipeline.id,
+      organization: sourceTestRun.organization.name,
       source_blob_url: sourceBlobUrl
     })
   }))
@@ -49,4 +50,3 @@ module.exports = {
   args: [{ name: 'number', optional: true }],
   run: cli.command(co.wrap(run))
 }
-

--- a/commands/ci/rerun.js
+++ b/commands/ci/rerun.js
@@ -26,13 +26,17 @@ function* run (context, heroku) {
     return yield source.createSourceBlob(sourceTestRun.commit_sha, context, heroku)
   }))
 
+  const pipelineRepository = yield api.pipelineRepository(heroku, pipeline.id)
+  const organization = pipelineRepository.organization &&
+                       pipelineRepository.organization.name
+
   const testRun = yield cli.action('Starting test run', co(function* () {
     return yield api.createTestRun(heroku, {
       commit_branch: sourceTestRun.commit_branch,
       commit_message: sourceTestRun.commit_message,
       commit_sha: sourceTestRun.commit_sha,
       pipeline: pipeline.id,
-      organization: sourceTestRun.organization.name,
+      organization,
       source_blob_url: sourceBlobUrl
     })
   }))

--- a/commands/ci/run.js
+++ b/commands/ci/run.js
@@ -14,12 +14,17 @@ function* run (context, heroku) {
     return yield source.createSourceBlob(commit.ref, context, heroku)
   }))
 
+  const pipelineRepository = yield api.pipelineRepository(heroku, pipeline.id)
+  const organization = pipelineRepository.organization &&
+                       pipelineRepository.organization.name
+
   const testRun = yield cli.action('Starting test run', co(function* () {
     return yield api.createTestRun(heroku, {
       commit_branch: commit.branch,
       commit_message: commit.message,
       commit_sha: commit.ref,
       pipeline: pipeline.id,
+      organization,
       source_blob_url: sourceBlobUrl
     })
   }))


### PR DESCRIPTION
We were not respecting the user configured organization option in the `ci:run` and `ci:rerun` commands, this fixes that.