### PR TITLE
heroku ci:config commands

### DIFF
--- a/commands/ci/config-get.js
+++ b/commands/ci/config-get.js
@@ -1,0 +1,37 @@
+const cli = require('heroku-cli-util')
+const co = require('co')
+const shellescape = require('shell-escape')
+const api = require('../../lib/heroku-api')
+
+function* run (context, heroku) {
+  const coupling = yield api.pipelineCoupling(heroku, context.app)
+  const config = yield api.configVars(heroku, coupling.pipeline.id)
+  const value = config[context.args.key]
+
+  if (context.flags.shell) {
+    cli.log(`${context.args.key}=${shellescape([value])}`)
+  } else {
+    cli.log(value)
+  }
+}
+
+module.exports = {
+  topic: 'ci',
+  command: 'config:get',
+  needsApp: true,
+  needsAuth: true,
+  description: 'get a CI config var',
+  help: `Examples:
+$ heroku ci:config:get RAILS_ENV
+test
+`,
+  args: [{
+    name: 'key'
+  }],
+  flags: [{
+    name: 'shell',
+    char: 's',
+    description: 'output config var in shell format'
+  }],
+  run: cli.command(co.wrap(run))
+}

--- a/commands/ci/config-index.js
+++ b/commands/ci/config-index.js
@@ -1,5 +1,6 @@
 const cli = require('heroku-cli-util')
 const co = require('co')
+const shellescape = require('shell-escape')
 const api = require('../../lib/heroku-api')
 
 function* run (context, heroku) {
@@ -7,7 +8,9 @@ function* run (context, heroku) {
   const config = yield api.configVars(heroku, coupling.pipeline.id)
 
   if (context.flags.shell) {
-    Object.keys(config).forEach((key) => cli.log(`${key}=${config[key]}`))
+    Object.keys(config).forEach((key) => {
+      cli.log(`${key}=${shellescape([config[key]])}`)
+    })
   } else if (context.flags.json) {
     cli.styledJSON(config)
   } else {

--- a/commands/ci/config-index.js
+++ b/commands/ci/config-index.js
@@ -1,0 +1,33 @@
+const cli = require('heroku-cli-util')
+const co = require('co')
+const api = require('../../lib/heroku-api')
+
+function* run (context, heroku) {
+  const coupling = yield api.pipelineCoupling(heroku, context.app)
+  const config = yield api.configVars(heroku, coupling.pipeline.id)
+
+  if (context.flags.shell) {
+    Object.keys(config).forEach((key) => cli.log(`${key}=${config[key]}`))
+  } else if (context.flags.json) {
+    cli.styledJSON(config)
+  } else {
+    cli.styledHeader(`${coupling.pipeline.name} test config vars`)
+    cli.styledObject(Object.keys(config).reduce((memo, key) => {
+      memo[cli.color.green(key)] = config[key]
+      return memo
+    }, {}))
+  }
+}
+
+module.exports = {
+  topic: 'ci',
+  command: 'config',
+  needsApp: true,
+  needsAuth: true,
+  description: 'display CI config vars',
+  flags: [
+    {name: 'shell', char: 's', description: 'output config vars in shell format'},
+    {name: 'json', description: 'output config vars in json format'}
+  ],
+  run: cli.command(co.wrap(run))
+}

--- a/commands/ci/config-set.js
+++ b/commands/ci/config-set.js
@@ -1,0 +1,56 @@
+const cli = require('heroku-cli-util')
+const co = require('co')
+const api = require('../../lib/heroku-api')
+
+function validateArgs (args) {
+  if (args.length === 0) {
+    cli.exit(1, 'Usage: heroku ci:config:set KEY1=VALUE1 [KEY2=VALUE2 ...]\nMust specify KEY and VALUE to set.')
+  }
+}
+
+function validateInput (str) {
+  if (!str.includes('=')) {
+    cli.exit(1, `${cli.color.cyan(str)} is invalid. Must be in the format ${cli.color.cyan('FOO=bar')}.`)
+  }
+
+  return true
+}
+
+function* run (context, heroku) {
+  validateArgs(context.args)
+
+  const vars = context.args.reduce((memo, str) => {
+    validateInput(str)
+    const [key, value] = str.split('=')
+    memo[key] = value
+    return memo
+  }, {})
+
+  const coupling = yield api.pipelineCoupling(heroku, context.app)
+
+  const config = yield cli.action(
+    `Setting ${Object.keys(vars).join(', ')}`,
+    api.setConfigVars(heroku, coupling.pipeline.id, vars)
+  )
+
+  cli.styledObject(Object.keys(vars).reduce((memo, key) => {
+    memo[cli.color.green(key)] = vars[key]
+    return memo
+  }, {}))
+}
+
+module.exports = {
+  topic: 'ci',
+  command: 'config:set',
+  needsApp: true,
+  needsAuth: true,
+  variableArgs: true,
+  description: 'set CI config vars',
+  help: `Examples:
+$ heroku ci:config:set RAILS_ENV=test
+Setting test config vars... done
+
+RAILS_ENV: test
+`,
+  run: cli.command(co.wrap(run))
+}

--- a/commands/ci/config-set.js
+++ b/commands/ci/config-set.js
@@ -28,7 +28,7 @@ function* run (context, heroku) {
 
   const coupling = yield api.pipelineCoupling(heroku, context.app)
 
-  const config = yield cli.action(
+  yield cli.action(
     `Setting ${Object.keys(vars).join(', ')}`,
     api.setConfigVars(heroku, coupling.pipeline.id, vars)
   )

--- a/commands/ci/config-unset.js
+++ b/commands/ci/config-unset.js
@@ -1,0 +1,39 @@
+const cli = require('heroku-cli-util')
+const co = require('co')
+const api = require('../../lib/heroku-api')
+
+function validateArgs (args) {
+  if (args.length === 0) {
+    cli.exit(1, 'Usage: heroku ci:config:set KEY1 [KEY2 ...]\nMust specify KEY to unset.')
+  }
+}
+
+function* run (context, heroku) {
+  validateArgs(context.args)
+
+  const vars = context.args.reduce((memo, key) => {
+    memo[key] = null
+    return memo
+  }, {})
+
+  const coupling = yield api.pipelineCoupling(heroku, context.app)
+
+  yield cli.action(
+    `Unsetting ${Object.keys(vars).join(', ')}`,
+    api.setConfigVars(heroku, coupling.pipeline.id, vars)
+  )
+}
+
+module.exports = {
+  topic: 'ci',
+  command: 'config:unset',
+  needsApp: true,
+  needsAuth: true,
+  variableArgs: true,
+  description: 'unset CI config vars',
+  help: `Examples:
+$ heroku ci:config:uset RAILS_ENV
+Unsetting RAILS_ENV... done
+`,
+  run: cli.command(co.wrap(run))
+}

--- a/lib/heroku-api.js
+++ b/lib/heroku-api.js
@@ -2,6 +2,7 @@ const https = require('https')
 const KOLKRABBI = 'https://kolkrabbi.heroku.com'
 const V3_HEADER = 'application/vnd.heroku+json; version=3'
 const VERSION_HEADER = `${V3_HEADER}.ci`
+const PIPELINE_HEADER = `${V3_HEADER}.pipelines`
 
 function* pipelineCoupling (client, app) {
   return client.get(`/apps/${app}/pipeline-couplings`)
@@ -81,10 +82,17 @@ function* createTestRun (client, body) {
   })
 }
 
+function configVars (client, pipelineID) {
+  return client.request({
+    headers: { Accept: PIPELINE_HEADER },
+    path: `/pipelines/${pipelineID}/stage/test/config-vars`
+  })
+}
+
 function setConfigVars (client, pipelineID, body) {
   return client.request({
     method: 'PATCH',
-    headers: { Accept: `${V3_HEADER}.pipelines` },
+    headers: { Accept: PIPELINE_HEADER },
     path: `/pipelines/${pipelineID}/stage/test/config-vars`,
     body
   })
@@ -100,5 +108,6 @@ module.exports = {
   logStream,
   createSource,
   createTestRun,
+  configVars,
   setConfigVars
 }

--- a/lib/heroku-api.js
+++ b/lib/heroku-api.js
@@ -1,6 +1,7 @@
 const https = require('https')
 const KOLKRABBI = 'https://kolkrabbi.heroku.com'
-const VERSION_HEADER = 'application/vnd.heroku+json; version=3.ci'
+const V3_HEADER = 'application/vnd.heroku+json; version=3'
+const VERSION_HEADER = `${V3_HEADER}.ci`
 
 function* pipelineCoupling (client, app) {
   return client.get(`/apps/${app}/pipeline-couplings`)
@@ -80,6 +81,15 @@ function* createTestRun (client, body) {
   })
 }
 
+function setConfigVars (client, pipelineID, body) {
+  return client.request({
+    method: 'PATCH',
+    headers: { Accept: `${V3_HEADER}.pipelines` },
+    path: `/pipelines/${pipelineID}/stage/test/config-vars`,
+    body
+  })
+}
+
 module.exports = {
   pipelineCoupling,
   pipelineRepository,
@@ -89,5 +99,6 @@ module.exports = {
   latestTestRun,
   logStream,
   createSource,
-  createTestRun
+  createTestRun,
+  setConfigVars
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "github-url-to-object": "^2.2.6",
     "got": "^6.6.3",
     "heroku-cli-util": "^6.0.15",
+    "shell-escape": "^0.2.0",
     "socket.io-client": "^1.5.1",
     "temp": "^0.8.3"
   }

--- a/test/commands/ci/config-get-test.js
+++ b/test/commands/ci/config-get-test.js
@@ -1,0 +1,50 @@
+/* eslint-env mocha */
+
+const nock = require('nock')
+const expect = require('chai').expect
+const cli = require('heroku-cli-util')
+const cmd = require('../../../commands/ci/config-get')
+
+describe('heroku ci:config:get', function () {
+  let app, coupling, key, value
+
+  beforeEach(function () {
+    cli.mockConsole()
+    app = '123-app'
+    key = 'FOO'
+    value = 'bar'
+
+    coupling = {
+      pipeline: {
+        id: '123-abc',
+        name: 'test-pipeline'
+      }
+    }
+  })
+
+  it('displays the config value', function* () {
+    const api = nock('https://api.heroku.com')
+      .get(`/apps/${app}/pipeline-couplings`)
+      .reply(200, coupling)
+      .get(`/pipelines/${coupling.pipeline.id}/stage/test/config-vars`)
+      .reply(200, { [key]: value })
+
+    yield cmd.run({ app, args: { key }, flags: {} })
+
+    expect(cli.stdout).to.equal(`${value}\n`)
+    api.done()
+  })
+
+  it('displays config formatted for shell', function* () {
+    const api = nock('https://api.heroku.com')
+      .get(`/apps/${app}/pipeline-couplings`)
+      .reply(200, coupling)
+      .get(`/pipelines/${coupling.pipeline.id}/stage/test/config-vars`)
+      .reply(200, { [key]: value })
+
+    yield cmd.run({ app, args: { key }, flags: { shell: true } })
+
+    expect(cli.stdout).to.equal(`${key}=${value}\n`)
+    api.done()
+  })
+})

--- a/test/commands/ci/config-index-test.js
+++ b/test/commands/ci/config-index-test.js
@@ -1,0 +1,63 @@
+/* eslint-env mocha */
+
+const nock = require('nock')
+const expect = require('chai').expect
+const cli = require('heroku-cli-util')
+const cmd = require('../../../commands/ci/config-index')
+
+describe('heroku ci:config', function () {
+  let app, coupling, key, value
+
+  beforeEach(function () {
+    cli.mockConsole()
+    app = '123-app'
+    key = 'FOO'
+    value = 'bar'
+
+    coupling = {
+      pipeline: {
+        id: '123-abc',
+        name: 'test-pipeline'
+      }
+    }
+  })
+
+  it('displays config', function* () {
+    const api = nock('https://api.heroku.com')
+      .get(`/apps/${app}/pipeline-couplings`)
+      .reply(200, coupling)
+      .get(`/pipelines/${coupling.pipeline.id}/stage/test/config-vars`)
+      .reply(200, { [key]: value })
+
+    yield cmd.run({ app, flags: {} })
+
+    expect(cli.stdout).to.include(`${key}: ${value}`)
+    api.done()
+  })
+
+  it('displays config formatted for shell', function* () {
+    const api = nock('https://api.heroku.com')
+      .get(`/apps/${app}/pipeline-couplings`)
+      .reply(200, coupling)
+      .get(`/pipelines/${coupling.pipeline.id}/stage/test/config-vars`)
+      .reply(200, { [key]: value })
+
+    yield cmd.run({ app, flags: { shell: true } })
+
+    expect(cli.stdout).to.include(`${key}=${value}`)
+    api.done()
+  })
+
+  it('displays config formatted as JSON', function* () {
+    const api = nock('https://api.heroku.com')
+      .get(`/apps/${app}/pipeline-couplings`)
+      .reply(200, coupling)
+      .get(`/pipelines/${coupling.pipeline.id}/stage/test/config-vars`)
+      .reply(200, { [key]: value })
+
+    yield cmd.run({ app, flags: { json: true } })
+
+    expect(cli.stdout).to.include('{\n  "FOO": "bar"\n}')
+    api.done()
+  })
+})

--- a/test/commands/ci/config-set-test.js
+++ b/test/commands/ci/config-set-test.js
@@ -1,0 +1,39 @@
+/* eslint-env mocha */
+
+const nock = require('nock')
+const expect = require('chai').expect
+const cli = require('heroku-cli-util')
+const cmd = require('../../../commands/ci/config-set')
+
+describe('heroku ci:config:set', function () {
+  let app, coupling, key, value
+
+  beforeEach(function () {
+    cli.mockConsole()
+    app = '123-app'
+    key = 'FOO'
+    value = 'bar'
+
+    coupling = {
+      pipeline: {
+        id: '123-abc',
+        name: 'test-pipeline'
+      }
+    }
+  })
+
+  it('sets new config', function* () {
+    const api = nock('https://api.heroku.com')
+      .get(`/apps/${app}/pipeline-couplings`)
+      .reply(200, coupling)
+      .patch(`/pipelines/${coupling.pipeline.id}/stage/test/config-vars`)
+      .reply(200, { [key]: value })
+
+    yield cmd.run({ app, args: [ `${key}=${value}` ] })
+
+    expect(cli.stdout).to.include(key)
+    expect(cli.stdout).to.include(value)
+
+    api.done()
+  })
+})

--- a/test/commands/ci/config-unset-test.js
+++ b/test/commands/ci/config-unset-test.js
@@ -1,0 +1,34 @@
+/* eslint-env mocha */
+
+const nock = require('nock')
+const cli = require('heroku-cli-util')
+const cmd = require('../../../commands/ci/config-unset')
+
+describe('heroku ci:config:unset', function () {
+  let app, coupling, key
+
+  beforeEach(function () {
+    cli.mockConsole()
+    app = '123-app'
+    key = 'FOO'
+
+    coupling = {
+      pipeline: {
+        id: '123-abc',
+        name: 'test-pipeline'
+      }
+    }
+  })
+
+  it('unsets config', function* () {
+    const api = nock('https://api.heroku.com')
+      .get(`/apps/${app}/pipeline-couplings`)
+      .reply(200, coupling)
+      .patch(`/pipelines/${coupling.pipeline.id}/stage/test/config-vars`)
+      .reply(200, { [key]: null })
+
+    yield cmd.run({ app, args: [ key ] })
+
+    api.done()
+  })
+})

--- a/test/lib/heroku-api-test.js
+++ b/test/lib/heroku-api-test.js
@@ -110,6 +110,20 @@ describe('heroku-api', function () {
     })
   })
 
+  describe('#configVars', function () {
+    it('gets config vars', function* () {
+      const id = '123'
+      const config = { FOO: 'bar' }
+      const api = nock(`https://api.heroku.com`)
+        .get(`/pipelines/${id}/stage/test/config-vars`)
+        .reply(200, config)
+
+      const response = yield herokuAPI.configVars(new Heroku(), id)
+      expect(response).to.deep.eq(config)
+      api.done()
+    })
+  })
+
   describe('#setConfigVars', function () {
     it('patches config vars', function* () {
       const id = '123'

--- a/test/lib/heroku-api-test.js
+++ b/test/lib/heroku-api-test.js
@@ -109,4 +109,18 @@ describe('heroku-api', function () {
       api.done()
     })
   })
+
+  describe('#setConfigVars', function () {
+    it('patches config vars', function* () {
+      const id = '123'
+      const config = { FOO: 'bar' }
+      const api = nock(`https://api.heroku.com`)
+        .patch(`/pipelines/${id}/stage/test/config-vars`)
+        .reply(200, config)
+
+      const response = yield herokuAPI.setConfigVars(new Heroku(), id, config)
+      expect(response).to.deep.eq(config)
+      api.done()
+    })
+  })
 })


### PR DESCRIPTION
Adds the following commands:

- `heroku ci:config`
- `heroku ci:config:get`
- `heroku ci:config:set`
- `heroku ci:config:unset`

I think this should eventually be a part of the regular `heroku config` command but we should let it bake here for a while first since ci is still in early beta.