### PR TITLE
Add migrate-manifest command

### DIFF
--- a/commands/ci/migrate-manifest.js
+++ b/commands/ci/migrate-manifest.js
@@ -66,7 +66,7 @@ function* run (context, heroku) {
     showWarning()
   }
 
-  cli.log(`You should be all set now! 🎉`)
+  cli.log(`You're all set! 🎉`)
 }
 
 module.exports = {
@@ -80,6 +80,7 @@ module.exports = {
 $ heroku ci:migrate-manifest
 Writing app.json file... done
 Deleting app-ci.json file... done
-You should be all set now! 🎉. Please check the contents of your app.json before committing to your repo`,
+Please check the contents of your app.json before committing to your repo
+You're all set! 🎉.`,
   run: cli.command(co.wrap(run))
 }

--- a/commands/ci/migrate-manifest.js
+++ b/commands/ci/migrate-manifest.js
@@ -8,38 +8,65 @@ const unlinkFile = BB.promisify(fs.unlink)
 function* run (context, heroku) {
   const appJSONPath = `${process.cwd()}/app.json`
   const appCiJSONPath = `${process.cwd()}/app-ci.json`
+  let action
+
+  function showWarning () {
+    cli.log(cli.color.green('Please check the contents of your app.json before committing to your repo.'))
+  }
+
+  function* updateAppJson () {
+    yield cli.action(
+      // Updating / Creating
+      `${action.charAt(0).toUpperCase() + action.slice(1)} app.json file`,
+      writeFile(appJSONPath, `${JSON.stringify(appJSON, null, '  ')}\n`)
+    )
+  }
 
   let appJSON, appCiJSON
 
   try {
     appJSON = require(appJSONPath)
+    action = 'updating'
   } catch (e) {
+    action = 'creating'
     appJSON = {}
   }
 
   try {
     appCiJSON = require(appCiJSONPath)
   } catch (e) {
-    throw new Error(`Couldn't load app-ci.json. This command must be run from a directory containing an app-ci.json file`)
+    let msg = `We couldn't find an app-ci.json file in the current directory`
+    if (appJSON.environments == null) {
+      msg += `, but we're ${action} ${action === 'updating' ? 'your' : 'a new'} app.json manifest for you.`
+      appJSON.environments = {}
+      cli.log(msg)
+      yield updateAppJson()
+      showWarning()
+    } else {
+      msg += `, and your app.json already has the environments key.`
+      cli.log(msg)
+    }
   }
 
-  if (appJSON.environments == null) {
-    appJSON.environments = {}
+  if (appCiJSON) {
+    if (appJSON.environments && appJSON.environments.test) {
+      cli.warn(`Your app.json already had a test key. We're overwriting it with the content of your app-ci.json`)
+    }
+
+    if (appJSON.environments == null) {
+      appJSON.environments = {}
+    }
+
+    appJSON.environments.test = appCiJSON
+    yield updateAppJson()
+    yield cli.action(
+      'Deleting app-ci.json file',
+      unlinkFile(appCiJSONPath)
+    )
+    showWarning()
   }
 
-  appJSON.environments.test = appCiJSON
-
-  yield cli.action(
-    'Writing app.json file',
-    writeFile(appJSONPath, `${JSON.stringify(appJSON, null, '  ')}\n`)
-  )
-
-  yield cli.action(
-    'Deleting app-ci.json file',
-    unlinkFile(appCiJSONPath)
-  )
-
-  cli.log('Migration successful. Please check the contents of your app.json before committing to your repo')
+  cli.log(`You should be all set now! 🎉`)
 }
 
 module.exports = {
@@ -53,6 +80,6 @@ module.exports = {
 $ heroku ci:migrate-manifest
 Writing app.json file... done
 Deleting app-ci.json file... done
-Migration successful. Please check the contents of your app.json before committing to your repo`,
+You should be all set now! 🎉. Please check the contents of your app.json before committing to your repo`,
   run: cli.command(co.wrap(run))
 }

--- a/commands/ci/migrate-manifest.js
+++ b/commands/ci/migrate-manifest.js
@@ -1,0 +1,58 @@
+const fs = require('fs')
+const cli = require('heroku-cli-util')
+const co = require('co')
+const BB = require('bluebird')
+const writeFile = BB.promisify(fs.writeFile)
+const unlinkFile = BB.promisify(fs.unlink)
+
+function* run (context, heroku) {
+  const appJSONPath = `${process.cwd()}/app.json`
+  const appCiJSONPath = `${process.cwd()}/app-ci.json`
+
+  let appJSON, appCiJSON
+
+  try {
+    appJSON = require(appJSONPath)
+  } catch (e) {
+    appJSON = {}
+  }
+
+  try {
+    appCiJSON = require(appCiJSONPath)
+  } catch (e) {
+    throw new Error(`Couldn't load app-ci.json. This command must be run from a directory containing an app-ci.json file`)
+  }
+
+  if (appJSON.environments == null) {
+    appJSON.environments = {}
+  }
+
+  appJSON.environments.test = appCiJSON
+
+  yield cli.action(
+    'Writing app.json file',
+    writeFile(appJSONPath, `${JSON.stringify(appJSON, null, '  ')}\n`)
+  )
+
+  yield cli.action(
+    'Deleting app-ci.json file',
+    unlinkFile(appCiJSONPath)
+  )
+
+  cli.log('Migration successful. Please check the contents of your app.json before committing to your repo')
+}
+
+module.exports = {
+  topic: 'ci',
+  command: 'migrate-manifest',
+  needsApp: false,
+  needsAuth: false,
+  description: 'app-ci.json is deprecated. Run this command to migrate to app.json with an environments key.',
+  help: `Example:
+
+$ heroku ci:migrate-manifest
+Writing app.json file... done
+Deleting app-ci.json file... done
+Migration successful. Please check the contents of your app.json before committing to your repo`,
+  run: cli.command(co.wrap(run))
+}


### PR DESCRIPTION
Add a command to read the `app-ci.json` and assign its contents to the `environments.test` key of an `app.json` file.