### PR TITLE
Use ci commands for debug

### DIFF
--- a/commands/ci/debug.js
+++ b/commands/ci/debug.js
@@ -7,7 +7,7 @@ const source = require('../../lib/source')
 const TestRun = require('../../lib/test-run')
 
 // Default command. Run setup, source profile.d scripts and open a bash session
-const SETUP_COMMAND = 'sprettur setup && for f in .profile.d/*; do source $f; done'
+const SETUP_COMMAND = 'ci setup && eval $(ci env)'
 const COMMAND = `${SETUP_COMMAND} && bash`
 
 function* run (context, heroku) {


### PR DESCRIPTION
We now alias `sprettur > ci` so we should use that here too.

## Blockers
- `sprettur env` command is not yet merged, so we'll need to wait for that.