### PR TITLE
Fix attempt at .toString on null for ci:debug

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -11,12 +11,17 @@ function runGit (...args) {
   const git = spawn('git', args)
 
   return new Promise((resolve, reject) => {
-    git.on('exit', (error) => {
-      const stderr = git.stderr.read().toString()
-      if (stderr.includes(NOT_A_GIT_REPOSITORY)) {
-        error = RUN_IN_A_GIT_REPOSITORY
+    git.on('exit', (exitCode) => {
+      if (exitCode === 0) {
+        return
       }
-      reject(error)
+
+      const stderr = git.stderr.read() || ''
+      if (stderr.toString().includes(NOT_A_GIT_REPOSITORY)) {
+        reject(RUN_IN_A_GIT_REPOSITORY)
+        return
+      }
+      reject(exitCode)
     })
 
     git.stdout.on('data', (data) => resolve(data.toString().trim()))


### PR DESCRIPTION
This addresses an issue where we were trying to `#toString()` when there was no output from stderr. Furthermore this only rejects promises with a non-zero exit code.

```
$ heroku ci:debug -a my-app
~/heroku/plugins/node_modules/heroku-ci/lib/git.js:15
      const stderr = git.stderr.read().toString()
                                      ^

TypeError: Cannot read property 'toString' of null
    at ChildProcess.git.on (~/heroku/plugins/node_modules/heroku-ci/lib/git.js:15:39)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:191:7)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:215:12)
```