### PR TITLE
Add heroku ci:open to show CI on Dashbaord from CLI

### DIFF
--- a/commands/ci/open.js
+++ b/commands/ci/open.js
@@ -1,15 +1,12 @@
 const cli = require('heroku-cli-util')
 const co = require('co')
-const opn = require('opn')
 const api = require('../../lib/heroku-api')
 
 function* run (context, heroku) {
   const coupling = yield api.pipelineCoupling(heroku, context.app)
   const couplingPipelineID = coupling.pipeline.id
 
-  opn(`https://dashboard.heroku.com/pipelines/${couplingPipelineID}/tests`)
-
-  return true
+  yield cli.open(`https://dashboard.heroku.com/pipelines/${couplingPipelineID}/tests`)
 }
 
 module.exports = {

--- a/commands/ci/open.js
+++ b/commands/ci/open.js
@@ -1,0 +1,23 @@
+const cli = require('heroku-cli-util')
+const co = require('co')
+const opn = require('opn')
+const api = require('../../lib/heroku-api')
+
+function* run (context, heroku) {
+  const coupling = yield api.pipelineCoupling(heroku, context.app)
+  const couplingPipelineID = coupling.pipeline.id
+
+  opn(`https://dashboard.heroku.com/pipelines/${couplingPipelineID}/tests`)
+
+  return true
+}
+
+module.exports = {
+  topic: 'ci',
+  command: 'open',
+  needsApp: true,
+  needsAuth: true,
+  description: 'open the Dashboard version of Heroku CI',
+  help: 'opens a browser to view the Dashboard version of Heroku CI',
+  run: cli.command(co.wrap(run))
+}

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "got": "^6.6.3",
     "heroku-cli-util": "^6.0.15",
     "heroku-run": "^3.4.3",
+    "opn": "^4.0.2",
     "shell-escape": "^0.2.0",
     "socket.io-client": "^1.5.1",
     "temp": "^0.8.3"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "got": "^6.6.3",
     "heroku-cli-util": "^6.0.15",
     "heroku-run": "^3.4.3",
-    "opn": "^4.0.2",
     "shell-escape": "^0.2.0",
     "socket.io-client": "^1.5.1",
     "temp": "^0.8.3"


### PR DESCRIPTION
closes #21 

@heroku/devex I took a crack at this late on Friday. I'm not wild about adding another dependency, but I wasn't sure about OS compatibility issues. Perhaps, I'll ask the CLI team. Mostly, I struggled with designing a test for this. If you all have ideas, I'd love to hear them.