### PR TITLE
Add test node support

### DIFF
--- a/lib/heroku-api.js
+++ b/lib/heroku-api.js
@@ -38,6 +38,16 @@ function* testRun (client, pipelineID, number) {
   })
 }
 
+function* testNodes (client, testRunIdD) {
+  return client.request({
+    path: `/test-runs/${testRunIdD}/test-nodes`,
+    headers: {
+      Authorization: `Bearer ${client.options.token}`,
+      Accept: VERSION_HEADER
+    }
+  })
+}
+
 function* testRuns (client, pipelineID) {
   return client.request({
     path: `/pipelines/${pipelineID}/test-runs`,
@@ -114,17 +124,18 @@ function appSetup (client, id) {
 }
 
 module.exports = {
-  pipelineCoupling,
-  pipelineRepository,
-  githubArchiveLink,
-  testRun,
-  testRuns,
-  latestTestRun,
-  logStream,
+  appSetup,
+  configVars,
   createSource,
   createTestRun,
-  updateTestRun,
-  configVars,
+  githubArchiveLink,
+  latestTestRun,
+  testNodes,
+  testRun,
+  testRuns,
+  logStream,
+  pipelineCoupling,
+  pipelineRepository,
   setConfigVars,
-  appSetup
+  updateTestRun
 }

--- a/lib/test-run.js
+++ b/lib/test-run.js
@@ -33,7 +33,7 @@ function stream (url) {
 
 function * display (pipeline, number, { heroku }) {
   let testRun = yield api.testRun(heroku, pipeline.id, number)
-  const testNodes = yield api.testNodes(heroku, testRun.id)
+  let testNodes = yield api.testNodes(heroku, testRun.id)
   let firstTestNode = testNodes[0]
 
   testRun = yield waitForStates(TestRunStatesUtil.BUILDING_STATES, testRun, { heroku })
@@ -46,10 +46,15 @@ function * display (pipeline, number, { heroku }) {
 
   testRun = yield waitForStates(TestRunStatesUtil.TERMINAL_STATES, testRun, { heroku })
 
+  // At this point, we know that testRun has a finished status,
+  // and we can check for exit_code from firstTestNode
+  testNodes = yield api.testNodes(heroku, testRun.id)
+  firstTestNode = testNodes[0]
+
   cli.log(/* newline 💃 */)
   cli.log(RenderTestRuns.printLine(testRun))
 
-  return testRun
+  return firstTestNode
 }
 
 function * displayAndExit (pipeline, number, { heroku }) {

--- a/lib/test-run.js
+++ b/lib/test-run.js
@@ -33,14 +33,16 @@ function stream (url) {
 
 function * display (pipeline, number, { heroku }) {
   let testRun = yield api.testRun(heroku, pipeline.id, number)
+  const testNodes = yield api.testNodes(heroku, testRun.id)
+  let firstTestNode = testNodes[0]
 
   testRun = yield waitForStates(TestRunStatesUtil.BUILDING_STATES, testRun, { heroku })
 
-  yield stream(testRun.setup_stream_url)
+  yield stream(firstTestNode.setup_stream_url)
 
   testRun = yield waitForStates(TestRunStatesUtil.RUNNING_STATES, testRun, { heroku })
 
-  yield stream(testRun.output_stream_url)
+  yield stream(firstTestNode.output_stream_url)
 
   testRun = yield waitForStates(TestRunStatesUtil.TERMINAL_STATES, testRun, { heroku })
 
@@ -51,8 +53,8 @@ function * display (pipeline, number, { heroku }) {
 }
 
 function * displayAndExit (pipeline, number, { heroku }) {
-  let testRun = yield display(pipeline, number, { heroku })
-  process.exit(testRun.exit_code)
+  let testNode = yield display(pipeline, number, { heroku })
+  process.exit(testNode.exit_code)
 }
 
 module.exports = {

--- a/test/commands/ci/last-test.js
+++ b/test/commands/ci/last-test.js
@@ -34,7 +34,8 @@ describe('heroku ci:last', function () {
     testNode = {
       output_stream_url: 'https://output.com/tests',
       setup_stream_url: 'https://output.com/setup',
-      test_run: { id: testRun.id }
+      test_run: { id: testRun.id },
+      exit_code: 1
     }
 
     setupOutput = ''
@@ -53,6 +54,8 @@ describe('heroku ci:last', function () {
       .reply(200, [testRun])
       .get(`/pipelines/${coupling.pipeline.id}/test-runs/${testRun.number}`)
       .reply(200, testRun)
+      .get(`/test-runs/${testRun.id}/test-nodes`)
+      .reply(200, [testNode])
       .get(`/test-runs/${testRun.id}/test-nodes`)
       .reply(200, [testNode])
 

--- a/test/commands/ci/last-test.js
+++ b/test/commands/ci/last-test.js
@@ -7,7 +7,7 @@ const sinon = require('sinon')
 const cmd = require('../../../commands/ci/last')
 
 describe('heroku ci:last', function () {
-  let app, coupling, testRun, setupOutput, testOutput
+  let app, coupling, testRun, testNode, setupOutput, testOutput
 
   beforeEach(function () {
     cli.mockConsole()
@@ -25,12 +25,16 @@ describe('heroku ci:last', function () {
     testRun = {
       id: '123-abc',
       number: 123,
-      output_stream_url: 'https://output.com/tests',
-      setup_stream_url: 'https://output.com/setup',
       pipeline: coupling.pipeline,
       status: 'succeeded',
       commit_sha: '123abc456def',
       commit_branch: 'master'
+    }
+
+    testNode = {
+      output_stream_url: 'https://output.com/tests',
+      setup_stream_url: 'https://output.com/setup',
+      test_run: { id: testRun.id }
     }
 
     setupOutput = ''
@@ -49,6 +53,8 @@ describe('heroku ci:last', function () {
       .reply(200, [testRun])
       .get(`/pipelines/${coupling.pipeline.id}/test-runs/${testRun.number}`)
       .reply(200, testRun)
+      .get(`/test-runs/${testRun.id}/test-nodes`)
+      .reply(200, [testNode])
 
     const streamAPI = nock('https://output.com')
       .get('/setup')

--- a/test/lib/heroku-api-test.js
+++ b/test/lib/heroku-api-test.js
@@ -1,3 +1,4 @@
+
 /* eslint-env mocha */
 
 const nock = require('nock')
@@ -63,6 +64,22 @@ describe('heroku-api', function () {
 
       const response = yield herokuAPI.testRun(new Heroku(), pipeline, number)
       expect(response).to.deep.eq(testRun)
+      api.done()
+    })
+  })
+
+  describe('#testNodes', function () {
+    it('gets a test run given a pipeline and number', function* () {
+      const testRun = { id: 'uuid-999' }
+      const testNode = { test_run: { id: testRun.id } }
+
+      const api = nock(`https://api.heroku.com`)
+        .get(`/test-runs/${testRun.id}/test-nodes`)
+        .matchHeader('Accept', 'application/vnd.heroku+json; version=3.ci')
+        .reply(200, [testNode])
+
+      const response = yield herokuAPI.testNodes(new Heroku(), testRun.id)
+      expect(response).to.deep.eq([testNode])
       api.done()
     })
   })


### PR DESCRIPTION
- Add new request to `/test-runs/:id/test-nodes`
- Use firstNode to stream (`setup_stream_url` and `output_stream_url`)
- Use firstNode terminal status to exit after displaying (see [`displayAndExit`](https://github.com/heroku/heroku-ci/search?utf8=%E2%9C%93&q=displayAndExit&type=) occurrences).