### PR TITLE
Add pipeline as a valid parameter for ci commands

### DIFF
--- a/lib/heroku-api.js
+++ b/lib/heroku-api.js
@@ -18,6 +18,10 @@ function* pipelineRepository (client, pipelineID) {
   })
 }
 
+function* pipelineInfo (client, pipeline) {
+  return client.get(`/pipelines/${pipeline}`)
+}
+
 function* githubArchiveLink (client, user, repository, ref) {
   return client.request({
     host: KOLKRABBI,
@@ -135,6 +139,7 @@ module.exports = {
   testRuns,
   logStream,
   pipelineCoupling,
+  pipelineInfo,
   pipelineRepository,
   setConfigVars,
   updateTestRun


### PR DESCRIPTION
## WIP

So it's possible to do things like:

```bash
$ heroku ci:debug --pipeline PIPELINE
```

