### PR TITLE
Add pipeline flag support to all ci commands

### DIFF
--- a/commands/ci/config-get.js
+++ b/commands/ci/config-get.js
@@ -2,10 +2,11 @@ const cli = require('heroku-cli-util')
 const co = require('co')
 const shellescape = require('shell-escape')
 const api = require('../../lib/heroku-api')
+const Utils = require('../../lib/utils')
 
 function* run (context, heroku) {
-  const coupling = yield api.pipelineCoupling(heroku, context.app)
-  const config = yield api.configVars(heroku, coupling.pipeline.id)
+  const pipeline = yield Utils.getPipeline(context, heroku)
+  const config = yield api.configVars(heroku, pipeline.id)
   const value = config[context.args.key]
 
   if (context.flags.shell) {
@@ -18,7 +19,7 @@ function* run (context, heroku) {
 module.exports = {
   topic: 'ci',
   command: 'config:get',
-  needsApp: true,
+  wantsApp: true,
   needsAuth: true,
   description: 'get a CI config var',
   help: `Examples:
@@ -28,10 +29,18 @@ test
   args: [{
     name: 'key'
   }],
-  flags: [{
-    name: 'shell',
-    char: 's',
-    description: 'output config var in shell format'
-  }],
+  flags: [
+    {
+      name: 'shell',
+      char: 's',
+      description: 'output config var in shell format'
+    },
+    {
+      name: 'pipeline',
+      char: 'p',
+      hasValue: true,
+      description: 'pipeline'
+    }
+  ],
   run: cli.command(co.wrap(run))
 }

--- a/commands/ci/config-index.js
+++ b/commands/ci/config-index.js
@@ -2,10 +2,11 @@ const cli = require('heroku-cli-util')
 const co = require('co')
 const shellescape = require('shell-escape')
 const api = require('../../lib/heroku-api')
+const Utils = require('../../lib/utils')
 
 function* run (context, heroku) {
-  const coupling = yield api.pipelineCoupling(heroku, context.app)
-  const config = yield api.configVars(heroku, coupling.pipeline.id)
+  const pipeline = yield Utils.getPipeline(context, heroku)
+  const config = yield api.configVars(heroku, pipeline.id)
 
   if (context.flags.shell) {
     Object.keys(config).forEach((key) => {
@@ -14,7 +15,7 @@ function* run (context, heroku) {
   } else if (context.flags.json) {
     cli.styledJSON(config)
   } else {
-    cli.styledHeader(`${coupling.pipeline.name} test config vars`)
+    cli.styledHeader(`${pipeline.name} test config vars`)
     cli.styledObject(Object.keys(config).reduce((memo, key) => {
       memo[cli.color.green(key)] = config[key]
       return memo
@@ -25,12 +26,25 @@ function* run (context, heroku) {
 module.exports = {
   topic: 'ci',
   command: 'config',
-  needsApp: true,
+  wantsApp: true,
   needsAuth: true,
   description: 'display CI config vars',
   flags: [
-    {name: 'shell', char: 's', description: 'output config vars in shell format'},
-    {name: 'json', description: 'output config vars in json format'}
+    {
+      name: 'shell',
+      char: 's',
+      description: 'output config vars in shell format'
+    },
+    {
+      name: 'json',
+      description: 'output config vars in json format'
+    },
+    {
+      name: 'pipeline',
+      char: 'p',
+      hasValue: true,
+      description: 'pipeline'
+    }
   ],
   run: cli.command(co.wrap(run))
 }

--- a/commands/ci/config-unset.js
+++ b/commands/ci/config-unset.js
@@ -1,6 +1,7 @@
 const cli = require('heroku-cli-util')
 const co = require('co')
 const api = require('../../lib/heroku-api')
+const Utils = require('../../lib/utils')
 
 function validateArgs (args) {
   if (args.length === 0) {
@@ -16,21 +17,29 @@ function* run (context, heroku) {
     return memo
   }, {})
 
-  const coupling = yield api.pipelineCoupling(heroku, context.app)
+  const pipeline = yield Utils.getPipeline(context, heroku)
 
   yield cli.action(
     `Unsetting ${Object.keys(vars).join(', ')}`,
-    api.setConfigVars(heroku, coupling.pipeline.id, vars)
+    api.setConfigVars(heroku, pipeline.id, vars)
   )
 }
 
 module.exports = {
   topic: 'ci',
   command: 'config:unset',
-  needsApp: true,
+  wantsApp: true,
   needsAuth: true,
   variableArgs: true,
   description: 'unset CI config vars',
+  flags: [
+    {
+      name: 'pipeline',
+      char: 'p',
+      hasValue: true,
+      description: 'pipeline'
+    }
+  ],
   help: `Examples:
 $ heroku ci:config:uset RAILS_ENV
 Unsetting RAILS_ENV... done

--- a/commands/ci/debug.js
+++ b/commands/ci/debug.js
@@ -5,24 +5,14 @@ const api = require('../../lib/heroku-api')
 const git = require('../../lib/git')
 const source = require('../../lib/source')
 const TestRun = require('../../lib/test-run')
+const Utils = require('../../lib/utils')
 
 // Default command. Run setup, source profile.d scripts and open a bash session
 const SETUP_COMMAND = 'ci setup && eval $(ci env)'
 const COMMAND = `${SETUP_COMMAND} && bash`
 
 function* run (context, heroku) {
-  let pipeline = context.flags.pipeline
-
-  let pipelineOrApp = pipeline || context.app
-
-  if (!pipelineOrApp) cli.exit(1, 'Required flag:  --pipeline PIPELINE or --app APP')
-
-  if (pipeline) {
-    pipeline = yield api.pipelineInfo(heroku, pipeline)
-  } else {
-    const coupling = yield api.pipelineCoupling(heroku, context.app)
-    pipeline = coupling.pipeline
-  }
+  const pipeline = Utils.getPipeline(context, heroku)
 
   const pipelineRepository = yield api.pipelineRepository(heroku, pipeline.id)
   const organization = pipelineRepository.organization &&

--- a/commands/ci/index.js
+++ b/commands/ci/index.js
@@ -1,12 +1,11 @@
 const cli = require('heroku-cli-util')
 const co = require('co')
-const api = require('../../lib/heroku-api')
 const RenderTestRuns = require('../../lib/render-test-runs')
+const Utils = require('../../lib/utils')
 
 function* run (context, heroku) {
-  const coupling = yield api.pipelineCoupling(heroku, context.app)
-
-  return yield RenderTestRuns.render(coupling.pipeline, { heroku, watch: context.flags.watch })
+  const pipeline = yield Utils.getPipeline(context, heroku)
+  return yield RenderTestRuns.render(pipeline, { heroku, watch: context.flags.watch })
 }
 
 const cmd = {

--- a/commands/ci/info.js
+++ b/commands/ci/info.js
@@ -1,22 +1,30 @@
 const cli = require('heroku-cli-util')
 const co = require('co')
-const api = require('../../lib/heroku-api')
 const TestRun = require('../../lib/test-run')
+const Utils = require('../../lib/utils')
 
 function* run (context, heroku) {
-  const coupling = yield api.pipelineCoupling(heroku, context.app)
-  return yield TestRun.displayAndExit(coupling.pipeline, context.args.number, { heroku })
+  const pipeline = yield Utils.getPipeline(context, heroku)
+  return yield TestRun.displayAndExit(pipeline, context.args.number, { heroku })
 }
 
 module.exports = {
   topic: 'ci',
   command: 'info',
-  needsApp: true,
+  wantsApp: true,
   needsAuth: true,
   args: [
     {
       name: 'number',
       description: 'the test run number to show'
+    }
+  ],
+  flags: [
+    {
+      name: 'pipeline',
+      char: 'p',
+      hasValue: true,
+      description: 'pipeline'
     }
   ],
   description: 'test run information',

--- a/commands/ci/last.js
+++ b/commands/ci/last.js
@@ -2,12 +2,11 @@ const cli = require('heroku-cli-util')
 const co = require('co')
 const api = require('../../lib/heroku-api')
 const TestRun = require('../../lib/test-run')
+const Utils = require('../../lib/utils')
 
 function* run (context, heroku) {
-  const coupling = yield api.pipelineCoupling(heroku, context.app)
-  const pipeline = coupling.pipeline
-  const pipelineID = pipeline.id
-  const lastRun = yield api.latestTestRun(heroku, pipelineID)
+  const pipeline = yield Utils.getPipeline(context, heroku)
+  const lastRun = yield api.latestTestRun(heroku, pipeline.id)
 
   if (!lastRun) {
     return cli.error('No Heroku CI runs found for this pipeline.')
@@ -19,9 +18,17 @@ function* run (context, heroku) {
 module.exports = {
   topic: 'ci',
   command: 'last',
-  needsApp: true,
+  wantsApp: true,
   needsAuth: true,
   description: 'get the results of the last run',
+  flags: [
+    {
+      name: 'pipeline',
+      char: 'p',
+      hasValue: true,
+      description: 'pipeline'
+    }
+  ],
   help: 'looks for the most recent run and returns the output of that run',
   run: cli.command(co.wrap(run))
 }

--- a/commands/ci/open.js
+++ b/commands/ci/open.js
@@ -1,20 +1,26 @@
 const cli = require('heroku-cli-util')
 const co = require('co')
-const api = require('../../lib/heroku-api')
+const Utils = require('../../lib/utils')
 
 function* run (context, heroku) {
-  const coupling = yield api.pipelineCoupling(heroku, context.app)
-  const couplingPipelineID = coupling.pipeline.id
-
-  yield cli.open(`https://dashboard.heroku.com/pipelines/${couplingPipelineID}/tests`)
+  const pipeline = yield Utils.getPipeline(context, heroku)
+  yield cli.open(`https://dashboard.heroku.com/pipelines/${pipeline.id}/tests`)
 }
 
 module.exports = {
   topic: 'ci',
   command: 'open',
-  needsApp: true,
+  wantsApp: true,
   needsAuth: true,
   description: 'open the Dashboard version of Heroku CI',
+  flags: [
+    {
+      name: 'pipeline',
+      char: 'p',
+      hasValue: true,
+      description: 'pipeline'
+    }
+  ],
   help: 'opens a browser to view the Dashboard version of Heroku CI',
   run: cli.command(co.wrap(run))
 }

--- a/commands/ci/rerun.js
+++ b/commands/ci/rerun.js
@@ -4,11 +4,10 @@ const co = require('co')
 const api = require('../../lib/heroku-api')
 const source = require('../../lib/source')
 const TestRun = require('../../lib/test-run')
+const Utils = require('../../lib/utils')
 
 function* run (context, heroku) {
-  const coupling = yield api.pipelineCoupling(heroku, context.app)
-  const pipeline = coupling.pipeline
-
+  const pipeline = yield Utils.getPipeline(context, heroku)
   let sourceTestRun
 
   if (context.args.number) {
@@ -47,10 +46,18 @@ function* run (context, heroku) {
 module.exports = {
   topic: 'ci',
   command: 'rerun',
-  needsApp: true,
+  wantsApp: true,
   needsAuth: true,
   description: 'rerun tests against current directory',
   help: 'uploads the contents of the current directory, using git archive, to Heroku and runs the tests',
   args: [{ name: 'number', optional: true }],
+  flags: [
+    {
+      name: 'pipeline',
+      char: 'p',
+      hasValue: true,
+      description: 'pipeline'
+    }
+  ],
   run: cli.command(co.wrap(run))
 }

--- a/commands/ci/run.js
+++ b/commands/ci/run.js
@@ -4,10 +4,10 @@ const api = require('../../lib/heroku-api')
 const git = require('../../lib/git')
 const source = require('../../lib/source')
 const TestRun = require('../../lib/test-run')
+const Utils = require('../../lib/utils')
 
 function* run (context, heroku) {
-  const coupling = yield api.pipelineCoupling(heroku, context.app)
-  const pipeline = coupling.pipeline
+  const pipeline = yield Utils.getPipeline(context, heroku)
 
   const commit = yield git.readCommit('HEAD')
   const sourceBlobUrl = yield cli.action('Preparing source', co(function* () {
@@ -35,9 +35,17 @@ function* run (context, heroku) {
 module.exports = {
   topic: 'ci',
   command: 'run',
-  needsApp: true,
+  wantsApp: true,
   needsAuth: true,
   description: 'run tests against current directory',
+  flags: [
+    {
+      name: 'pipeline',
+      char: 'p',
+      hasValue: true,
+      description: 'pipeline'
+    }
+  ],
   help: 'uploads the contents of the current directory to Heroku and runs the tests',
   run: cli.command(co.wrap(run))
 }

--- a/lib/heroku-api.js
+++ b/lib/heroku-api.js
@@ -18,10 +18,6 @@ function* pipelineRepository (client, pipelineID) {
   })
 }
 
-function* pipelineInfo (client, pipeline) {
-  return client.get(`/pipelines/${pipeline}`)
-}
-
 function* githubArchiveLink (client, user, repository, ref) {
   return client.request({
     host: KOLKRABBI,
@@ -139,7 +135,6 @@ module.exports = {
   testRuns,
   logStream,
   pipelineCoupling,
-  pipelineInfo,
   pipelineRepository,
   setConfigVars,
   updateTestRun

--- a/lib/heroku-api.js
+++ b/lib/heroku-api.js
@@ -18,6 +18,10 @@ function* pipelineRepository (client, pipelineID) {
   })
 }
 
+function* pipelineInfo (client, pipeline) {
+  return client.get(`/pipelines/${pipeline}`)
+}
+
 function* githubArchiveLink (client, user, repository, ref) {
   return client.request({
     host: KOLKRABBI,
@@ -135,6 +139,7 @@ module.exports = {
   testRuns,
   logStream,
   pipelineCoupling,
+  pipelineInfo,
   pipelineRepository,
   setConfigVars,
   updateTestRun

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,6 @@
 const api = require('./heroku-api')
 const cli = require('heroku-cli-util')
+const disambiguatePipeline = require('heroku-pipelines').disambiguatePipeline
 
 function * getPipeline (context, client) {
   let pipeline = context.flags.pipeline
@@ -8,7 +9,7 @@ function * getPipeline (context, client) {
   if (!pipelineOrApp) cli.exit(1, 'Required flag:  --pipeline PIPELINE or --app APP')
 
   if (pipeline) {
-    pipeline = yield api.pipelineInfo(client, pipeline)
+    pipeline = yield disambiguatePipeline(client, pipeline)
   } else {
     const coupling = yield api.pipelineCoupling(client, context.app)
     pipeline = coupling.pipeline

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,22 @@
+const api = require('./heroku-api')
+const cli = require('heroku-cli-util')
+
+function * getPipeline (context, client) {
+  let pipeline = context.flags.pipeline
+
+  let pipelineOrApp = pipeline || context.app
+  if (!pipelineOrApp) cli.exit(1, 'Required flag:  --pipeline PIPELINE or --app APP')
+
+  if (pipeline) {
+    pipeline = yield api.pipelineInfo(client, pipeline)
+  } else {
+    const coupling = yield api.pipelineCoupling(client, context.app)
+    pipeline = coupling.pipeline
+  }
+
+  return pipeline
+}
+
+module.exports = {
+  getPipeline
+}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "github-url-to-object": "^2.2.6",
     "got": "^6.6.3",
     "heroku-cli-util": "^6.0.15",
+    "heroku-pipelines": "^2.0.1",
     "heroku-run": "^3.4.3",
     "lodash.flatten": "^4.4.0",
     "shell-escape": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "co-wait": "0.0.0",
     "github-url-to-object": "^2.2.6",
     "got": "^6.6.3",
-    "heroku-cli-util": "^6.0.15",
+    "heroku-cli-util": "^6.1.17",
     "heroku-pipelines": "^2.0.1",
     "heroku-run": "^3.4.3",
     "lodash.flatten": "^4.4.0",

--- a/test/commands/ci/config-get-test.js
+++ b/test/commands/ci/config-get-test.js
@@ -7,85 +7,38 @@ const cmd = require('../../../commands/ci/config-get')
 const Factory = require('../../lib/factory')
 
 describe('heroku ci:config:get', function () {
-  let key, value
+  let key, pipeline, value
 
   beforeEach(function () {
     cli.mockConsole()
     key = 'FOO'
     value = 'bar'
+    pipeline = Factory.pipeline
   })
 
-  context('when given an application', function () {
-    let app, coupling
+  it('displays the config value', function* () {
+    const api = nock('https://api.heroku.com')
+      .get(`/pipelines/${pipeline.id}`)
+      .reply(200, pipeline)
+      .get(`/pipelines/${pipeline.id}/stage/test/config-vars`)
+      .reply(200, { [key]: value })
 
-    beforeEach(function () {
-      app = '123-app'
-      coupling = {
-        pipeline: {
-          id: '123e4567-e89b-12d3-a456-426655440000',
-          name: 'test-pipeline'
-        }
-      }
-    })
+    yield cmd.run({ args: { key }, flags: { pipeline: pipeline.id } })
 
-    it('displays the config value', function* () {
-      const api = nock('https://api.heroku.com')
-        .get(`/apps/${app}/pipeline-couplings`)
-        .reply(200, coupling)
-        .get(`/pipelines/${coupling.pipeline.id}/stage/test/config-vars`)
-        .reply(200, { [key]: value })
-
-      yield cmd.run({ app, args: { key }, flags: {} })
-
-      expect(cli.stdout).to.equal(`${value}\n`)
-      api.done()
-    })
-
-    it('displays config formatted for shell', function* () {
-      const api = nock('https://api.heroku.com')
-        .get(`/apps/${app}/pipeline-couplings`)
-        .reply(200, coupling)
-        .get(`/pipelines/${coupling.pipeline.id}/stage/test/config-vars`)
-        .reply(200, { [key]: value })
-
-      yield cmd.run({ app, args: { key }, flags: { shell: true } })
-
-      expect(cli.stdout).to.equal(`${key}=${value}\n`)
-      api.done()
-    })
+    expect(cli.stdout).to.equal(`${value}\n`)
+    api.done()
   })
 
-  context('when given a pipeline', function () {
-    let pipeline
+  it('displays config formatted for shell', function* () {
+    const api = nock('https://api.heroku.com')
+      .get(`/pipelines/${pipeline.id}`)
+      .reply(200, pipeline)
+      .get(`/pipelines/${pipeline.id}/stage/test/config-vars`)
+      .reply(200, { [key]: value })
 
-    beforeEach(function () {
-      pipeline = Factory.pipeline
-    })
+    yield cmd.run({ args: { key }, flags: { shell: true, pipeline: pipeline.id } })
 
-    it('displays the config value', function* () {
-      const api = nock('https://api.heroku.com')
-        .get(`/pipelines/${pipeline.id}`)
-        .reply(200, pipeline)
-        .get(`/pipelines/${pipeline.id}/stage/test/config-vars`)
-        .reply(200, { [key]: value })
-
-      yield cmd.run({ args: { key }, flags: { pipeline: pipeline.id } })
-
-      expect(cli.stdout).to.equal(`${value}\n`)
-      api.done()
-    })
-
-    it('displays config formatted for shell', function* () {
-      const api = nock('https://api.heroku.com')
-        .get(`/pipelines/${pipeline.id}`)
-        .reply(200, pipeline)
-        .get(`/pipelines/${pipeline.id}/stage/test/config-vars`)
-        .reply(200, { [key]: value })
-
-      yield cmd.run({ args: { key }, flags: { shell: true, pipeline: pipeline.id } })
-
-      expect(cli.stdout).to.equal(`${key}=${value}\n`)
-      api.done()
-    })
+    expect(cli.stdout).to.equal(`${key}=${value}\n`)
+    api.done()
   })
 })

--- a/test/commands/ci/config-get-test.js
+++ b/test/commands/ci/config-get-test.js
@@ -6,45 +6,88 @@ const cli = require('heroku-cli-util')
 const cmd = require('../../../commands/ci/config-get')
 
 describe('heroku ci:config:get', function () {
-  let app, coupling, key, value
+  let key, value
 
   beforeEach(function () {
     cli.mockConsole()
-    app = '123-app'
     key = 'FOO'
     value = 'bar'
+  })
 
-    coupling = {
-      pipeline: {
+  context('when given an application', function () {
+    let app, coupling
+
+    beforeEach(function () {
+      app = '123-app'
+      coupling = {
+        pipeline: {
+          id: '123-abc',
+          name: 'test-pipeline'
+        }
+      }
+    })
+
+    it('displays the config value', function* () {
+      const api = nock('https://api.heroku.com')
+        .get(`/apps/${app}/pipeline-couplings`)
+        .reply(200, coupling)
+        .get(`/pipelines/${coupling.pipeline.id}/stage/test/config-vars`)
+        .reply(200, { [key]: value })
+
+      yield cmd.run({ app, args: { key }, flags: {} })
+
+      expect(cli.stdout).to.equal(`${value}\n`)
+      api.done()
+    })
+
+    it('displays config formatted for shell', function* () {
+      const api = nock('https://api.heroku.com')
+        .get(`/apps/${app}/pipeline-couplings`)
+        .reply(200, coupling)
+        .get(`/pipelines/${coupling.pipeline.id}/stage/test/config-vars`)
+        .reply(200, { [key]: value })
+
+      yield cmd.run({ app, args: { key }, flags: { shell: true } })
+
+      expect(cli.stdout).to.equal(`${key}=${value}\n`)
+      api.done()
+    })
+  })
+
+  context('when given a pipeline', function () {
+    let pipeline
+
+    beforeEach(function () {
+      pipeline = {
         id: '123-abc',
         name: 'test-pipeline'
       }
-    }
-  })
+    })
 
-  it('displays the config value', function* () {
-    const api = nock('https://api.heroku.com')
-      .get(`/apps/${app}/pipeline-couplings`)
-      .reply(200, coupling)
-      .get(`/pipelines/${coupling.pipeline.id}/stage/test/config-vars`)
-      .reply(200, { [key]: value })
+    it('displays the config value', function* () {
+      const api = nock('https://api.heroku.com')
+        .get(`/pipelines/${pipeline.name}`)
+        .reply(200, pipeline)
+        .get(`/pipelines/${pipeline.id}/stage/test/config-vars`)
+        .reply(200, { [key]: value })
 
-    yield cmd.run({ app, args: { key }, flags: {} })
+      yield cmd.run({ args: { key }, flags: { pipeline: pipeline.name } })
 
-    expect(cli.stdout).to.equal(`${value}\n`)
-    api.done()
-  })
+      expect(cli.stdout).to.equal(`${value}\n`)
+      api.done()
+    })
 
-  it('displays config formatted for shell', function* () {
-    const api = nock('https://api.heroku.com')
-      .get(`/apps/${app}/pipeline-couplings`)
-      .reply(200, coupling)
-      .get(`/pipelines/${coupling.pipeline.id}/stage/test/config-vars`)
-      .reply(200, { [key]: value })
+    it('displays config formatted for shell', function* () {
+      const api = nock('https://api.heroku.com')
+        .get(`/pipelines/${pipeline.name}`)
+        .reply(200, pipeline)
+        .get(`/pipelines/${pipeline.id}/stage/test/config-vars`)
+        .reply(200, { [key]: value })
 
-    yield cmd.run({ app, args: { key }, flags: { shell: true } })
+      yield cmd.run({ args: { key }, flags: { shell: true, pipeline: 'test-pipeline' } })
 
-    expect(cli.stdout).to.equal(`${key}=${value}\n`)
-    api.done()
+      expect(cli.stdout).to.equal(`${key}=${value}\n`)
+      api.done()
+    })
   })
 })

--- a/test/commands/ci/config-get-test.js
+++ b/test/commands/ci/config-get-test.js
@@ -4,6 +4,7 @@ const nock = require('nock')
 const expect = require('chai').expect
 const cli = require('heroku-cli-util')
 const cmd = require('../../../commands/ci/config-get')
+const Factory = require('../../lib/factory')
 
 describe('heroku ci:config:get', function () {
   let key, value
@@ -21,7 +22,7 @@ describe('heroku ci:config:get', function () {
       app = '123-app'
       coupling = {
         pipeline: {
-          id: '123-abc',
+          id: '123e4567-e89b-12d3-a456-426655440000',
           name: 'test-pipeline'
         }
       }
@@ -58,20 +59,17 @@ describe('heroku ci:config:get', function () {
     let pipeline
 
     beforeEach(function () {
-      pipeline = {
-        id: '123-abc',
-        name: 'test-pipeline'
-      }
+      pipeline = Factory.pipeline
     })
 
     it('displays the config value', function* () {
       const api = nock('https://api.heroku.com')
-        .get(`/pipelines/${pipeline.name}`)
+        .get(`/pipelines/${pipeline.id}`)
         .reply(200, pipeline)
         .get(`/pipelines/${pipeline.id}/stage/test/config-vars`)
         .reply(200, { [key]: value })
 
-      yield cmd.run({ args: { key }, flags: { pipeline: pipeline.name } })
+      yield cmd.run({ args: { key }, flags: { pipeline: pipeline.id } })
 
       expect(cli.stdout).to.equal(`${value}\n`)
       api.done()
@@ -79,12 +77,12 @@ describe('heroku ci:config:get', function () {
 
     it('displays config formatted for shell', function* () {
       const api = nock('https://api.heroku.com')
-        .get(`/pipelines/${pipeline.name}`)
+        .get(`/pipelines/${pipeline.id}`)
         .reply(200, pipeline)
         .get(`/pipelines/${pipeline.id}/stage/test/config-vars`)
         .reply(200, { [key]: value })
 
-      yield cmd.run({ args: { key }, flags: { shell: true, pipeline: 'test-pipeline' } })
+      yield cmd.run({ args: { key }, flags: { shell: true, pipeline: pipeline.id } })
 
       expect(cli.stdout).to.equal(`${key}=${value}\n`)
       api.done()

--- a/test/commands/ci/config-index-test.js
+++ b/test/commands/ci/config-index-test.js
@@ -7,112 +7,51 @@ const cmd = require('../../../commands/ci/config-index')
 const Factory = require('../../lib/factory')
 
 describe('heroku ci:config', function () {
-  let key, value
+  let key, pipeline, value
 
   beforeEach(function () {
     cli.mockConsole()
     key = 'FOO'
     value = 'bar'
+    pipeline = Factory.pipeline
   })
 
-  context('when given an application', function () {
-    let app, coupling
+  it('displays config', function* () {
+    const api = nock('https://api.heroku.com')
+      .get(`/pipelines/${pipeline.id}`)
+      .reply(200, pipeline)
+      .get(`/pipelines/${pipeline.id}/stage/test/config-vars`)
+      .reply(200, { [key]: value })
 
-    beforeEach(function () {
-      app = '123-app'
+    yield cmd.run({ flags: { pipeline: pipeline.id } })
 
-      coupling = {
-        pipeline: {
-          id: '123-abc',
-          name: 'test-pipeline'
-        }
-      }
-    })
-
-    it('displays config', function* () {
-      const api = nock('https://api.heroku.com')
-        .get(`/apps/${app}/pipeline-couplings`)
-        .reply(200, coupling)
-        .get(`/pipelines/${coupling.pipeline.id}/stage/test/config-vars`)
-        .reply(200, { [key]: value })
-
-      yield cmd.run({ app, flags: {} })
-
-      expect(cli.stdout).to.include(`${key}: ${value}`)
-      api.done()
-    })
-
-    it('displays config formatted for shell', function* () {
-      const api = nock('https://api.heroku.com')
-        .get(`/apps/${app}/pipeline-couplings`)
-        .reply(200, coupling)
-        .get(`/pipelines/${coupling.pipeline.id}/stage/test/config-vars`)
-        .reply(200, { [key]: value })
-
-      yield cmd.run({ app, flags: { shell: true } })
-
-      expect(cli.stdout).to.include(`${key}=${value}`)
-      api.done()
-    })
-
-    it('displays config formatted as JSON', function* () {
-      const api = nock('https://api.heroku.com')
-        .get(`/apps/${app}/pipeline-couplings`)
-        .reply(200, coupling)
-        .get(`/pipelines/${coupling.pipeline.id}/stage/test/config-vars`)
-        .reply(200, { [key]: value })
-
-      yield cmd.run({ app, flags: { json: true } })
-
-      expect(cli.stdout).to.include('{\n  "FOO": "bar"\n}')
-      api.done()
-    })
+    expect(cli.stdout).to.include(`${key}: ${value}`)
+    api.done()
   })
 
-  context('when given a pipeline', function () {
-    let pipeline
+  it('displays config formatted for shell', function* () {
+    const api = nock('https://api.heroku.com')
+      .get(`/pipelines/${pipeline.id}`)
+      .reply(200, pipeline)
+      .get(`/pipelines/${pipeline.id}/stage/test/config-vars`)
+      .reply(200, { [key]: value })
 
-    beforeEach(function () {
-      pipeline = Factory.pipeline
-    })
+    yield cmd.run({ flags: { shell: true, pipeline: pipeline.id } })
 
-    it('displays config', function* () {
-      const api = nock('https://api.heroku.com')
-        .get(`/pipelines/${pipeline.id}`)
-        .reply(200, pipeline)
-        .get(`/pipelines/${pipeline.id}/stage/test/config-vars`)
-        .reply(200, { [key]: value })
+    expect(cli.stdout).to.include(`${key}=${value}`)
+    api.done()
+  })
 
-      yield cmd.run({ flags: { pipeline: pipeline.id } })
+  it('displays config formatted as JSON', function* () {
+    const api = nock('https://api.heroku.com')
+      .get(`/pipelines/${pipeline.id}`)
+      .reply(200, pipeline)
+      .get(`/pipelines/${pipeline.id}/stage/test/config-vars`)
+      .reply(200, { [key]: value })
 
-      expect(cli.stdout).to.include(`${key}: ${value}`)
-      api.done()
-    })
+    yield cmd.run({ flags: { json: true, pipeline: pipeline.id } })
 
-    it('displays config formatted for shell', function* () {
-      const api = nock('https://api.heroku.com')
-        .get(`/pipelines/${pipeline.id}`)
-        .reply(200, pipeline)
-        .get(`/pipelines/${pipeline.id}/stage/test/config-vars`)
-        .reply(200, { [key]: value })
-
-      yield cmd.run({ flags: { shell: true, pipeline: pipeline.id } })
-
-      expect(cli.stdout).to.include(`${key}=${value}`)
-      api.done()
-    })
-
-    it('displays config formatted as JSON', function* () {
-      const api = nock('https://api.heroku.com')
-        .get(`/pipelines/${pipeline.id}`)
-        .reply(200, pipeline)
-        .get(`/pipelines/${pipeline.id}/stage/test/config-vars`)
-        .reply(200, { [key]: value })
-
-      yield cmd.run({ flags: { json: true, pipeline: pipeline.id } })
-
-      expect(cli.stdout).to.include('{\n  "FOO": "bar"\n}')
-      api.done()
-    })
+    expect(cli.stdout).to.include('{\n  "FOO": "bar"\n}')
+    api.done()
   })
 })

--- a/test/commands/ci/config-index-test.js
+++ b/test/commands/ci/config-index-test.js
@@ -4,6 +4,7 @@ const nock = require('nock')
 const expect = require('chai').expect
 const cli = require('heroku-cli-util')
 const cmd = require('../../../commands/ci/config-index')
+const Factory = require('../../lib/factory')
 
 describe('heroku ci:config', function () {
   let key, value
@@ -72,20 +73,17 @@ describe('heroku ci:config', function () {
     let pipeline
 
     beforeEach(function () {
-      pipeline = {
-        id: '123-abc',
-        name: 'test-pipeline'
-      }
+      pipeline = Factory.pipeline
     })
 
     it('displays config', function* () {
       const api = nock('https://api.heroku.com')
-        .get(`/pipelines/${pipeline.name}`)
+        .get(`/pipelines/${pipeline.id}`)
         .reply(200, pipeline)
         .get(`/pipelines/${pipeline.id}/stage/test/config-vars`)
         .reply(200, { [key]: value })
 
-      yield cmd.run({ flags: { pipeline: pipeline.name } })
+      yield cmd.run({ flags: { pipeline: pipeline.id } })
 
       expect(cli.stdout).to.include(`${key}: ${value}`)
       api.done()
@@ -93,12 +91,12 @@ describe('heroku ci:config', function () {
 
     it('displays config formatted for shell', function* () {
       const api = nock('https://api.heroku.com')
-        .get(`/pipelines/${pipeline.name}`)
+        .get(`/pipelines/${pipeline.id}`)
         .reply(200, pipeline)
         .get(`/pipelines/${pipeline.id}/stage/test/config-vars`)
         .reply(200, { [key]: value })
 
-      yield cmd.run({ flags: { shell: true, pipeline: pipeline.name } })
+      yield cmd.run({ flags: { shell: true, pipeline: pipeline.id } })
 
       expect(cli.stdout).to.include(`${key}=${value}`)
       api.done()
@@ -106,12 +104,12 @@ describe('heroku ci:config', function () {
 
     it('displays config formatted as JSON', function* () {
       const api = nock('https://api.heroku.com')
-        .get(`/pipelines/${pipeline.name}`)
+        .get(`/pipelines/${pipeline.id}`)
         .reply(200, pipeline)
         .get(`/pipelines/${pipeline.id}/stage/test/config-vars`)
         .reply(200, { [key]: value })
 
-      yield cmd.run({ flags: { json: true, pipeline: pipeline.name } })
+      yield cmd.run({ flags: { json: true, pipeline: pipeline.id } })
 
       expect(cli.stdout).to.include('{\n  "FOO": "bar"\n}')
       api.done()

--- a/test/commands/ci/config-set-test.js
+++ b/test/commands/ci/config-set-test.js
@@ -6,34 +6,67 @@ const cli = require('heroku-cli-util')
 const cmd = require('../../../commands/ci/config-set')
 
 describe('heroku ci:config:set', function () {
-  let app, coupling, key, value
+  let key, value
 
   beforeEach(function () {
     cli.mockConsole()
-    app = '123-app'
     key = 'FOO'
     value = 'bar'
+  })
 
-    coupling = {
-      pipeline: {
+  context('when given an application', function () {
+    let app, coupling
+
+    beforeEach(function () {
+      app = '123-app'
+
+      coupling = {
+        pipeline: {
+          id: '123-abc',
+          name: 'test-pipeline'
+        }
+      }
+    })
+
+    it('sets new config', function* () {
+      const api = nock('https://api.heroku.com')
+        .get(`/apps/${app}/pipeline-couplings`)
+        .reply(200, coupling)
+        .patch(`/pipelines/${coupling.pipeline.id}/stage/test/config-vars`)
+        .reply(200, { [key]: value })
+
+      yield cmd.run({ app, args: [ `${key}=${value}` ], flags: {} })
+
+      expect(cli.stdout).to.include(key)
+      expect(cli.stdout).to.include(value)
+
+      api.done()
+    })
+  })
+
+  context('when given a pipeline', function () {
+    let pipeline
+
+    beforeEach(function () {
+      pipeline = {
         id: '123-abc',
         name: 'test-pipeline'
       }
-    }
-  })
+    })
 
-  it('sets new config', function* () {
-    const api = nock('https://api.heroku.com')
-      .get(`/apps/${app}/pipeline-couplings`)
-      .reply(200, coupling)
-      .patch(`/pipelines/${coupling.pipeline.id}/stage/test/config-vars`)
-      .reply(200, { [key]: value })
+    it('sets new config', function* () {
+      const api = nock('https://api.heroku.com')
+        .get(`/pipelines/${pipeline.name}`)
+        .reply(200, pipeline)
+        .patch(`/pipelines/${pipeline.id}/stage/test/config-vars`)
+        .reply(200, { [key]: value })
 
-    yield cmd.run({ app, args: [ `${key}=${value}` ], flags: [] })
+      yield cmd.run({ args: [ `${key}=${value}` ], flags: { pipeline: pipeline.name } })
 
-    expect(cli.stdout).to.include(key)
-    expect(cli.stdout).to.include(value)
+      expect(cli.stdout).to.include(key)
+      expect(cli.stdout).to.include(value)
 
-    api.done()
+      api.done()
+    })
   })
 })

--- a/test/commands/ci/config-set-test.js
+++ b/test/commands/ci/config-set-test.js
@@ -29,7 +29,7 @@ describe('heroku ci:config:set', function () {
       .patch(`/pipelines/${coupling.pipeline.id}/stage/test/config-vars`)
       .reply(200, { [key]: value })
 
-    yield cmd.run({ app, args: [ `${key}=${value}` ] })
+    yield cmd.run({ app, args: [ `${key}=${value}` ], flags: [] })
 
     expect(cli.stdout).to.include(key)
     expect(cli.stdout).to.include(value)

--- a/test/commands/ci/config-set-test.js
+++ b/test/commands/ci/config-set-test.js
@@ -4,6 +4,7 @@ const nock = require('nock')
 const expect = require('chai').expect
 const cli = require('heroku-cli-util')
 const cmd = require('../../../commands/ci/config-set')
+const Factory = require('../../lib/factory')
 
 describe('heroku ci:config:set', function () {
   let key, value
@@ -48,20 +49,17 @@ describe('heroku ci:config:set', function () {
     let pipeline
 
     beforeEach(function () {
-      pipeline = {
-        id: '123-abc',
-        name: 'test-pipeline'
-      }
+      pipeline = Factory.pipeline
     })
 
     it('sets new config', function* () {
       const api = nock('https://api.heroku.com')
-        .get(`/pipelines/${pipeline.name}`)
+        .get(`/pipelines/${pipeline.id}`)
         .reply(200, pipeline)
         .patch(`/pipelines/${pipeline.id}/stage/test/config-vars`)
         .reply(200, { [key]: value })
 
-      yield cmd.run({ args: [ `${key}=${value}` ], flags: { pipeline: pipeline.name } })
+      yield cmd.run({ args: [ `${key}=${value}` ], flags: { pipeline: pipeline.id } })
 
       expect(cli.stdout).to.include(key)
       expect(cli.stdout).to.include(value)

--- a/test/commands/ci/config-unset-test.js
+++ b/test/commands/ci/config-unset-test.js
@@ -3,6 +3,7 @@
 const nock = require('nock')
 const cli = require('heroku-cli-util')
 const cmd = require('../../../commands/ci/config-unset')
+const Factory = require('../../lib/factory')
 
 describe('heroku ci:config:unset', function () {
   let key
@@ -43,20 +44,17 @@ describe('heroku ci:config:unset', function () {
     let pipeline
 
     beforeEach(function () {
-      pipeline = {
-        id: '123-abc',
-        name: 'test-pipeline'
-      }
+      pipeline = Factory.pipeline
     })
 
     it('unsets config', function* () {
       const api = nock('https://api.heroku.com')
-        .get(`/pipelines/${pipeline.name}`)
+        .get(`/pipelines/${pipeline.id}`)
         .reply(200, pipeline)
         .patch(`/pipelines/${pipeline.id}/stage/test/config-vars`)
         .reply(200, { [key]: null })
 
-      yield cmd.run({ args: [ key ], flags: { pipeline: pipeline.name } })
+      yield cmd.run({ args: [ key ], flags: { pipeline: pipeline.id } })
       api.done()
     })
   })

--- a/test/commands/ci/config-unset-test.js
+++ b/test/commands/ci/config-unset-test.js
@@ -27,7 +27,7 @@ describe('heroku ci:config:unset', function () {
       .patch(`/pipelines/${coupling.pipeline.id}/stage/test/config-vars`)
       .reply(200, { [key]: null })
 
-    yield cmd.run({ app, args: [ key ] })
+    yield cmd.run({ app, args: [ key ], flags: [] })
 
     api.done()
   })

--- a/test/commands/ci/config-unset-test.js
+++ b/test/commands/ci/config-unset-test.js
@@ -5,30 +5,59 @@ const cli = require('heroku-cli-util')
 const cmd = require('../../../commands/ci/config-unset')
 
 describe('heroku ci:config:unset', function () {
-  let app, coupling, key
+  let key
 
   beforeEach(function () {
     cli.mockConsole()
-    app = '123-app'
     key = 'FOO'
+  })
 
-    coupling = {
-      pipeline: {
+  context('when given an application', function () {
+    let app, coupling
+
+    beforeEach(function () {
+      app = '123-app'
+
+      coupling = {
+        pipeline: {
+          id: '123-abc',
+          name: 'test-pipeline'
+        }
+      }
+    })
+
+    it('unsets config', function* () {
+      const api = nock('https://api.heroku.com')
+        .get(`/apps/${app}/pipeline-couplings`)
+        .reply(200, coupling)
+        .patch(`/pipelines/${coupling.pipeline.id}/stage/test/config-vars`)
+        .reply(200, { [key]: null })
+
+      yield cmd.run({ app, args: [ key ], flags: {} })
+
+      api.done()
+    })
+  })
+
+  context('when given a pipeline', function () {
+    let pipeline
+
+    beforeEach(function () {
+      pipeline = {
         id: '123-abc',
         name: 'test-pipeline'
       }
-    }
-  })
+    })
 
-  it('unsets config', function* () {
-    const api = nock('https://api.heroku.com')
-      .get(`/apps/${app}/pipeline-couplings`)
-      .reply(200, coupling)
-      .patch(`/pipelines/${coupling.pipeline.id}/stage/test/config-vars`)
-      .reply(200, { [key]: null })
+    it('unsets config', function* () {
+      const api = nock('https://api.heroku.com')
+        .get(`/pipelines/${pipeline.name}`)
+        .reply(200, pipeline)
+        .patch(`/pipelines/${pipeline.id}/stage/test/config-vars`)
+        .reply(200, { [key]: null })
 
-    yield cmd.run({ app, args: [ key ], flags: [] })
-
-    api.done()
+      yield cmd.run({ args: [ key ], flags: { pipeline: pipeline.name } })
+      api.done()
+    })
   })
 })

--- a/test/commands/ci/config-unset-test.js
+++ b/test/commands/ci/config-unset-test.js
@@ -6,56 +6,22 @@ const cmd = require('../../../commands/ci/config-unset')
 const Factory = require('../../lib/factory')
 
 describe('heroku ci:config:unset', function () {
-  let key
+  let pipeline, key
 
   beforeEach(function () {
     cli.mockConsole()
     key = 'FOO'
+    pipeline = Factory.pipeline
   })
 
-  context('when given an application', function () {
-    let app, coupling
+  it('unsets config', function* () {
+    const api = nock('https://api.heroku.com')
+      .get(`/pipelines/${pipeline.id}`)
+      .reply(200, pipeline)
+      .patch(`/pipelines/${pipeline.id}/stage/test/config-vars`)
+      .reply(200, { [key]: null })
 
-    beforeEach(function () {
-      app = '123-app'
-
-      coupling = {
-        pipeline: {
-          id: '123-abc',
-          name: 'test-pipeline'
-        }
-      }
-    })
-
-    it('unsets config', function* () {
-      const api = nock('https://api.heroku.com')
-        .get(`/apps/${app}/pipeline-couplings`)
-        .reply(200, coupling)
-        .patch(`/pipelines/${coupling.pipeline.id}/stage/test/config-vars`)
-        .reply(200, { [key]: null })
-
-      yield cmd.run({ app, args: [ key ], flags: {} })
-
-      api.done()
-    })
-  })
-
-  context('when given a pipeline', function () {
-    let pipeline
-
-    beforeEach(function () {
-      pipeline = Factory.pipeline
-    })
-
-    it('unsets config', function* () {
-      const api = nock('https://api.heroku.com')
-        .get(`/pipelines/${pipeline.id}`)
-        .reply(200, pipeline)
-        .patch(`/pipelines/${pipeline.id}/stage/test/config-vars`)
-        .reply(200, { [key]: null })
-
-      yield cmd.run({ args: [ key ], flags: { pipeline: pipeline.id } })
-      api.done()
-    })
+    yield cmd.run({ args: [ key ], flags: { pipeline: pipeline.id } })
+    api.done()
   })
 })

--- a/test/commands/ci/index-test.js
+++ b/test/commands/ci/index-test.js
@@ -5,6 +5,7 @@ const expect = require('chai').expect
 const cli = require('heroku-cli-util')
 const cmd = require('../../../commands/ci')[0]
 const stdMocks = require('std-mocks')
+const Factory = require('../../lib/factory')
 
 describe('heroku ci', function () {
   let runs
@@ -61,22 +62,19 @@ describe('heroku ci', function () {
     let pipeline
 
     beforeEach(function () {
-      pipeline = {
-        id: '123-abc',
-        name: 'test-pipeline'
-      }
+      pipeline = Factory.pipeline
     })
 
     it('displays recent runs', function* () {
       const api = nock('https://api.heroku.com')
-        .get(`/pipelines/${pipeline.name}`)
+        .get(`/pipelines/${pipeline.id}`)
         .reply(200, pipeline)
         .get(`/pipelines/${pipeline.id}/test-runs`)
         .reply(200, runs)
 
       stdMocks.use()
 
-      yield cmd.run({ flags: { pipeline: pipeline.name } })
+      yield cmd.run({ flags: { pipeline: pipeline.id } })
 
       stdMocks.restore()
       const { stdout } = stdMocks.flush()

--- a/test/commands/ci/last-test.js
+++ b/test/commands/ci/last-test.js
@@ -7,25 +7,13 @@ const sinon = require('sinon')
 const cmd = require('../../../commands/ci/last')
 
 describe('heroku ci:last', function () {
-  let app, coupling, testRun, testNode, setupOutput, testOutput
+  let testRun, testNode, setupOutput, testOutput
 
-  beforeEach(function () {
-    cli.mockConsole()
-    sinon.stub(process, 'exit')
-
-    app = '123-app'
-
-    coupling = {
-      pipeline: {
-        id: '123-abc',
-        name: '123-abc'
-      }
-    }
-
+  function setup (pipeline) {
     testRun = {
       id: '123-abc',
       number: 123,
-      pipeline: coupling.pipeline,
+      pipeline: pipeline,
       status: 'succeeded',
       commit_sha: '123abc456def',
       commit_branch: 'master'
@@ -37,6 +25,11 @@ describe('heroku ci:last', function () {
       test_run: { id: testRun.id },
       exit_code: 1
     }
+  }
+
+  beforeEach(function () {
+    cli.mockConsole()
+    sinon.stub(process, 'exit')
 
     setupOutput = ''
     testOutput = ''
@@ -46,41 +39,109 @@ describe('heroku ci:last', function () {
     process.exit.restore()
   })
 
-  it('when pipeline has runs, displays the results of the latest run', function* () {
-    const api = nock('https://api.heroku.com')
-      .get(`/apps/${app}/pipeline-couplings`)
-      .reply(200, coupling)
-      .get(`/pipelines/${coupling.pipeline.id}/test-runs`)
-      .reply(200, [testRun])
-      .get(`/pipelines/${coupling.pipeline.id}/test-runs/${testRun.number}`)
-      .reply(200, testRun)
-      .get(`/test-runs/${testRun.id}/test-nodes`)
-      .reply(200, [testNode])
-      .get(`/test-runs/${testRun.id}/test-nodes`)
-      .reply(200, [testNode])
+  context('when given an application', function () {
+    let app, coupling
 
-    const streamAPI = nock('https://output.com')
-      .get('/setup')
-      .reply(200, setupOutput)
-      .get('/tests')
-      .reply(200, testOutput)
+    beforeEach(function () {
+      app = '123-app'
 
-    yield cmd.run({ app, flags: [] })
-    expect(cli.stdout).to.contain(`✓ #${testRun.number}`)
+      coupling = {
+        pipeline: {
+          id: '123-abc',
+          name: '123-abc'
+        }
+      }
 
-    api.done()
-    streamAPI.done()
+      setup(coupling.pipeline)
+    })
+
+    it('and its pipeline has runs, displays the results of the latest run', function* () {
+      const api = nock('https://api.heroku.com')
+        .get(`/apps/${app}/pipeline-couplings`)
+        .reply(200, coupling)
+        .get(`/pipelines/${coupling.pipeline.id}/test-runs`)
+        .reply(200, [testRun])
+        .get(`/pipelines/${coupling.pipeline.id}/test-runs/${testRun.number}`)
+        .reply(200, testRun)
+        .get(`/test-runs/${testRun.id}/test-nodes`)
+        .reply(200, [testNode])
+        .get(`/test-runs/${testRun.id}/test-nodes`)
+        .reply(200, [testNode])
+
+      const streamAPI = nock('https://output.com')
+        .get('/setup')
+        .reply(200, setupOutput)
+        .get('/tests')
+        .reply(200, testOutput)
+
+      yield cmd.run({ app, flags: {} })
+      expect(cli.stdout).to.contain(`✓ #${testRun.number}`)
+
+      api.done()
+      streamAPI.done()
+    })
+
+    it('and its pipeline does not have any runs, reports that there are no runs', function* () {
+      let api = nock('https://api.heroku.com')
+        .get(`/apps/${app}/pipeline-couplings`)
+        .reply(200, coupling)
+        .get(`/pipelines/${coupling.pipeline.id}/test-runs`)
+        .reply(200, [])
+
+      yield cmd.run({ app, flags: {} })
+      expect(cli.stderr).to.contain('No Heroku CI runs found')
+      api.done()
+    })
   })
 
-  it('when pipeline does not have any runs, reports that there are no runs', function* () {
-    let api = nock('https://api.heroku.com')
-      .get(`/apps/${app}/pipeline-couplings`)
-      .reply(200, coupling)
-      .get(`/pipelines/${coupling.pipeline.id}/test-runs`)
-      .reply(200, [])
+  context('when given a pipeline', function () {
+    let pipeline
 
-    yield cmd.run({ app, flags: [] })
-    expect(cli.stderr).to.contain('No Heroku CI runs found')
-    api.done()
+    beforeEach(function () {
+      pipeline = {
+        id: '123-abc',
+        name: '123-abc'
+      }
+
+      setup(pipeline)
+    })
+
+    it('with runs, displays the results of the latest run', function* () {
+      const api = nock('https://api.heroku.com')
+        .get(`/pipelines/${pipeline.name}`)
+        .reply(200, pipeline)
+        .get(`/pipelines/${pipeline.id}/test-runs`)
+        .reply(200, [testRun])
+        .get(`/pipelines/${pipeline.id}/test-runs/${testRun.number}`)
+        .reply(200, testRun)
+        .get(`/test-runs/${testRun.id}/test-nodes`)
+        .reply(200, [testNode])
+        .get(`/test-runs/${testRun.id}/test-nodes`)
+        .reply(200, [testNode])
+
+      const streamAPI = nock('https://output.com')
+        .get('/setup')
+        .reply(200, setupOutput)
+        .get('/tests')
+        .reply(200, testOutput)
+
+      yield cmd.run({ flags: { pipeline: pipeline.name } })
+      expect(cli.stdout).to.contain(`✓ #${testRun.number}`)
+
+      api.done()
+      streamAPI.done()
+    })
+
+    it('without any runs, reports that there are no runs', function* () {
+      let api = nock('https://api.heroku.com')
+        .get(`/pipelines/${pipeline.name}`)
+        .reply(200, pipeline)
+        .get(`/pipelines/${pipeline.id}/test-runs`)
+        .reply(200, [])
+
+      yield cmd.run({ flags: { pipeline: pipeline.name } })
+      expect(cli.stderr).to.contain('No Heroku CI runs found')
+      api.done()
+    })
   })
 })

--- a/test/commands/ci/last-test.js
+++ b/test/commands/ci/last-test.js
@@ -5,6 +5,7 @@ const expect = require('chai').expect
 const cli = require('heroku-cli-util')
 const sinon = require('sinon')
 const cmd = require('../../../commands/ci/last')
+const Factory = require('../../lib/factory')
 
 describe('heroku ci:last', function () {
   let testRun, testNode, setupOutput, testOutput
@@ -98,17 +99,13 @@ describe('heroku ci:last', function () {
     let pipeline
 
     beforeEach(function () {
-      pipeline = {
-        id: '123-abc',
-        name: '123-abc'
-      }
-
+      pipeline = Factory.pipeline
       setup(pipeline)
     })
 
     it('with runs, displays the results of the latest run', function* () {
       const api = nock('https://api.heroku.com')
-        .get(`/pipelines/${pipeline.name}`)
+        .get(`/pipelines/${pipeline.id}`)
         .reply(200, pipeline)
         .get(`/pipelines/${pipeline.id}/test-runs`)
         .reply(200, [testRun])
@@ -125,7 +122,7 @@ describe('heroku ci:last', function () {
         .get('/tests')
         .reply(200, testOutput)
 
-      yield cmd.run({ flags: { pipeline: pipeline.name } })
+      yield cmd.run({ flags: { pipeline: pipeline.id } })
       expect(cli.stdout).to.contain(`✓ #${testRun.number}`)
 
       api.done()
@@ -134,12 +131,12 @@ describe('heroku ci:last', function () {
 
     it('without any runs, reports that there are no runs', function* () {
       let api = nock('https://api.heroku.com')
-        .get(`/pipelines/${pipeline.name}`)
+        .get(`/pipelines/${pipeline.id}`)
         .reply(200, pipeline)
         .get(`/pipelines/${pipeline.id}/test-runs`)
         .reply(200, [])
 
-      yield cmd.run({ flags: { pipeline: pipeline.name } })
+      yield cmd.run({ flags: { pipeline: pipeline.id } })
       expect(cli.stderr).to.contain('No Heroku CI runs found')
       api.done()
     })

--- a/test/commands/ci/last-test.js
+++ b/test/commands/ci/last-test.js
@@ -65,7 +65,7 @@ describe('heroku ci:last', function () {
       .get('/tests')
       .reply(200, testOutput)
 
-    yield cmd.run({ app })
+    yield cmd.run({ app, flags: [] })
     expect(cli.stdout).to.contain(`✓ #${testRun.number}`)
 
     api.done()
@@ -79,7 +79,7 @@ describe('heroku ci:last', function () {
       .get(`/pipelines/${coupling.pipeline.id}/test-runs`)
       .reply(200, [])
 
-    yield cmd.run({ app })
+    yield cmd.run({ app, flags: [] })
     expect(cli.stderr).to.contain('No Heroku CI runs found')
     api.done()
   })

--- a/test/commands/ci/last-test.js
+++ b/test/commands/ci/last-test.js
@@ -8,9 +8,16 @@ const cmd = require('../../../commands/ci/last')
 const Factory = require('../../lib/factory')
 
 describe('heroku ci:last', function () {
-  let testRun, testNode, setupOutput, testOutput
+  let testRun, testNode, setupOutput, pipeline, testOutput
 
-  function setup (pipeline) {
+  beforeEach(function () {
+    cli.mockConsole()
+    sinon.stub(process, 'exit')
+
+    setupOutput = ''
+    testOutput = ''
+    pipeline = Factory.pipeline
+
     testRun = {
       id: '123-abc',
       number: 123,
@@ -26,119 +33,47 @@ describe('heroku ci:last', function () {
       test_run: { id: testRun.id },
       exit_code: 1
     }
-  }
-
-  beforeEach(function () {
-    cli.mockConsole()
-    sinon.stub(process, 'exit')
-
-    setupOutput = ''
-    testOutput = ''
   })
 
   afterEach(function () {
     process.exit.restore()
   })
 
-  context('when given an application', function () {
-    let app, coupling
+  it('with runs, displays the results of the latest run', function* () {
+    const api = nock('https://api.heroku.com')
+      .get(`/pipelines/${pipeline.id}`)
+      .reply(200, pipeline)
+      .get(`/pipelines/${pipeline.id}/test-runs`)
+      .reply(200, [testRun])
+      .get(`/pipelines/${pipeline.id}/test-runs/${testRun.number}`)
+      .reply(200, testRun)
+      .get(`/test-runs/${testRun.id}/test-nodes`)
+      .reply(200, [testNode])
+      .get(`/test-runs/${testRun.id}/test-nodes`)
+      .reply(200, [testNode])
 
-    beforeEach(function () {
-      app = '123-app'
+    const streamAPI = nock('https://output.com')
+      .get('/setup')
+      .reply(200, setupOutput)
+      .get('/tests')
+      .reply(200, testOutput)
 
-      coupling = {
-        pipeline: {
-          id: '123-abc',
-          name: '123-abc'
-        }
-      }
+    yield cmd.run({ flags: { pipeline: pipeline.id } })
+    expect(cli.stdout).to.contain(`✓ #${testRun.number}`)
 
-      setup(coupling.pipeline)
-    })
-
-    it('and its pipeline has runs, displays the results of the latest run', function* () {
-      const api = nock('https://api.heroku.com')
-        .get(`/apps/${app}/pipeline-couplings`)
-        .reply(200, coupling)
-        .get(`/pipelines/${coupling.pipeline.id}/test-runs`)
-        .reply(200, [testRun])
-        .get(`/pipelines/${coupling.pipeline.id}/test-runs/${testRun.number}`)
-        .reply(200, testRun)
-        .get(`/test-runs/${testRun.id}/test-nodes`)
-        .reply(200, [testNode])
-        .get(`/test-runs/${testRun.id}/test-nodes`)
-        .reply(200, [testNode])
-
-      const streamAPI = nock('https://output.com')
-        .get('/setup')
-        .reply(200, setupOutput)
-        .get('/tests')
-        .reply(200, testOutput)
-
-      yield cmd.run({ app, flags: {} })
-      expect(cli.stdout).to.contain(`✓ #${testRun.number}`)
-
-      api.done()
-      streamAPI.done()
-    })
-
-    it('and its pipeline does not have any runs, reports that there are no runs', function* () {
-      let api = nock('https://api.heroku.com')
-        .get(`/apps/${app}/pipeline-couplings`)
-        .reply(200, coupling)
-        .get(`/pipelines/${coupling.pipeline.id}/test-runs`)
-        .reply(200, [])
-
-      yield cmd.run({ app, flags: {} })
-      expect(cli.stderr).to.contain('No Heroku CI runs found')
-      api.done()
-    })
+    api.done()
+    streamAPI.done()
   })
 
-  context('when given a pipeline', function () {
-    let pipeline
+  it('without any runs, reports that there are no runs', function* () {
+    let api = nock('https://api.heroku.com')
+      .get(`/pipelines/${pipeline.id}`)
+      .reply(200, pipeline)
+      .get(`/pipelines/${pipeline.id}/test-runs`)
+      .reply(200, [])
 
-    beforeEach(function () {
-      pipeline = Factory.pipeline
-      setup(pipeline)
-    })
-
-    it('with runs, displays the results of the latest run', function* () {
-      const api = nock('https://api.heroku.com')
-        .get(`/pipelines/${pipeline.id}`)
-        .reply(200, pipeline)
-        .get(`/pipelines/${pipeline.id}/test-runs`)
-        .reply(200, [testRun])
-        .get(`/pipelines/${pipeline.id}/test-runs/${testRun.number}`)
-        .reply(200, testRun)
-        .get(`/test-runs/${testRun.id}/test-nodes`)
-        .reply(200, [testNode])
-        .get(`/test-runs/${testRun.id}/test-nodes`)
-        .reply(200, [testNode])
-
-      const streamAPI = nock('https://output.com')
-        .get('/setup')
-        .reply(200, setupOutput)
-        .get('/tests')
-        .reply(200, testOutput)
-
-      yield cmd.run({ flags: { pipeline: pipeline.id } })
-      expect(cli.stdout).to.contain(`✓ #${testRun.number}`)
-
-      api.done()
-      streamAPI.done()
-    })
-
-    it('without any runs, reports that there are no runs', function* () {
-      let api = nock('https://api.heroku.com')
-        .get(`/pipelines/${pipeline.id}`)
-        .reply(200, pipeline)
-        .get(`/pipelines/${pipeline.id}/test-runs`)
-        .reply(200, [])
-
-      yield cmd.run({ flags: { pipeline: pipeline.id } })
-      expect(cli.stderr).to.contain('No Heroku CI runs found')
-      api.done()
-    })
+    yield cmd.run({ flags: { pipeline: pipeline.id } })
+    expect(cli.stderr).to.contain('No Heroku CI runs found')
+    api.done()
   })
 })

--- a/test/lib/factory.js
+++ b/test/lib/factory.js
@@ -1,0 +1,8 @@
+const Factory = {
+  pipeline: {
+    id: '123e4567-e89b-12d3-a456-426655440000',
+    name: 'test-pipeline'
+  }
+}
+
+module.exports = Factory

--- a/test/lib/heroku-api-test.js
+++ b/test/lib/heroku-api-test.js
@@ -23,20 +23,6 @@ describe('heroku-api', function () {
     })
   })
 
-  describe('#pipelineInfo', function () {
-    it('gets the pipeline information given a pipeline name', function* () {
-      const pipelineName = 'sausages'
-      const pipeline = { id: '123-abc', pipelineName }
-      const api = nock(`https://api.heroku.com`)
-        .get(`/pipelines/${pipelineName}`)
-        .reply(200, pipeline)
-
-      const response = yield herokuAPI.pipelineInfo(new Heroku(), pipelineName)
-      expect(response).to.deep.eq(pipeline)
-      api.done()
-    })
-  })
-
   describe('#pipelineRepository', function () {
     it('gets the pipeline repository given a pipeline', function* () {
       const pipeline = '123-abc'

--- a/test/lib/heroku-api-test.js
+++ b/test/lib/heroku-api-test.js
@@ -23,6 +23,20 @@ describe('heroku-api', function () {
     })
   })
 
+  describe('#pipelineInfo', function () {
+    it('gets the pipeline information given a pipeline name', function* () {
+      const pipelineName = 'sausages'
+      const pipeline = { id: '123-abc', pipelineName }
+      const api = nock(`https://api.heroku.com`)
+        .get(`/pipelines/${pipelineName}`)
+        .reply(200, pipeline)
+
+      const response = yield herokuAPI.pipelineInfo(new Heroku(), pipelineName)
+      expect(response).to.deep.eq(pipeline)
+      api.done()
+    })
+  })
+
   describe('#pipelineRepository', function () {
     it('gets the pipeline repository given a pipeline', function* () {
       const pipeline = '123-abc'

--- a/test/lib/utils-test.js
+++ b/test/lib/utils-test.js
@@ -1,0 +1,40 @@
+/* eslint-env mocha */
+
+const nock = require('nock')
+const expect = require('chai').expect
+const Heroku = require('heroku-client')
+const Utils = require('../../lib/utils')
+const Factory = require('./factory')
+
+describe.only('Utils', function () {
+  afterEach(() => nock.cleanAll())
+
+  describe('#getPipeline', function () {
+    it('disambiguates when passing a pipeline', function* () {
+      const pipeline = Factory.pipeline
+      const context = { flags: { pipeline: pipeline.id } }
+      const api = nock(`https://api.heroku.com`)
+        .get(`/pipelines/${pipeline.id}`)
+        .reply(200, pipeline)
+
+      const response = yield Utils.getPipeline(context, new Heroku())
+      expect(response).to.deep.eq(Factory.pipeline)
+      api.done()
+    })
+
+    it('uses pipeline-couplings when passing an application', function* () {
+      const app = '123-app'
+
+      const coupling = { pipeline: Factory.pipeline }
+      const context = { app, flags: {} }
+
+      const api = nock('https://api.heroku.com')
+        .get(`/apps/${app}/pipeline-couplings`)
+        .reply(200, coupling)
+
+      const response = yield Utils.getPipeline(context, new Heroku())
+      expect(response).to.deep.eq(Factory.pipeline)
+      api.done()
+    })
+  })
+})

--- a/test/lib/utils-test.js
+++ b/test/lib/utils-test.js
@@ -6,7 +6,7 @@ const Heroku = require('heroku-client')
 const Utils = require('../../lib/utils')
 const Factory = require('./factory')
 
-describe.only('Utils', function () {
+describe('Utils', function () {
   afterEach(() => nock.cleanAll())
 
   describe('#getPipeline', function () {


### PR DESCRIPTION
Add support to:

```bash
$ heroku ci --pipeline PIPELINE
$ heroku ci:config --pipeline PIPELINE
$ heroku ci:config:get --pipeline PIPELINE
$ heroku ci:config:set --pipeline PIPELINE
$ heroku ci:config:unset --pipeline PIPELINE
$ heroku ci:debug --pipeline PIPELINE
$ heroku ci:info NUMBER --pipeline PIPELINE
$ heroku ci:last --pipeline PIPELINE
$ heroku ci:last --pipeline PIPELINE
$ heroku ci:open --pipeline PIPELINE
$ heroku ci:rerun NUMBER --pipeline PIPELINE
$ heroku ci:run --pipeline PIPELINE
```

When neither an app or a pipeline is specified, this is the error message shown:

```
 ▸    Required flag:  --pipeline PIPELINE or --app APP
```

**Note:**

Eventually, `--pipelines` should be one of the main flags and wouldn't be necessary to be manually added like in this PR. Tracking that future work in this card: https://trello.com/c/hZAmrWEm/2675-make-pipeline-one-of-the-main-flags-in-the-cli-engine.