### PR TITLE
Fix async issue when fetching pipeline info

### DIFF
--- a/commands/ci/debug.js
+++ b/commands/ci/debug.js
@@ -12,7 +12,7 @@ const SETUP_COMMAND = 'ci setup && eval $(ci env)'
 const COMMAND = `${SETUP_COMMAND} && bash`
 
 function* run (context, heroku) {
-  const pipeline = Utils.getPipeline(context, heroku)
+  const pipeline = yield Utils.getPipeline(context, heroku)
 
   const pipelineRepository = yield api.pipelineRepository(heroku, pipeline.id)
   const organization = pipelineRepository.organization &&


### PR DESCRIPTION
This fixes a not found message users are experiencing when running `heroku ci:debug`:

Fixes:

```bash
› heroku ci:debug --pipeline my-pipe
 ▸    Not found.
```
