### PR TITLE
Stream from an attached url when dyno was previously started

### DIFF
--- a/commands/ci/debug.js
+++ b/commands/ci/debug.js
@@ -79,20 +79,21 @@ function* run (context, heroku) {
   let dynoPromise
   if (dynoID) {
     dyno.attach_url = (
-      yield api.getDyno(heroku, appSetup.app.id, testNode.dyno.id)
+      yield api.getDyno(heroku, appSetup.app.id, dynoID)
     ).attach_url
     dynoPromise = dyno.attach()
   } else {
     dynoPromise = dyno.start()
   }
 
-  if (!noSetup) {
-    function sendSetup (data, connection) {
-      if (data.toString().includes('$')) {
-        dyno.write(SETUP_COMMAND + '\n')
-        dyno.removeListener('data', sendSetup)
-      }
+  function sendSetup (data, connection) {
+    if (data.toString().includes('$')) {
+      dyno.write(SETUP_COMMAND + '\n')
+      dyno.removeListener('data', sendSetup)
     }
+  }
+
+  if (!noSetup) {
     dyno.on('data', sendSetup)
   }
 

--- a/commands/ci/debug.js
+++ b/commands/ci/debug.js
@@ -28,10 +28,11 @@ function* run (context, heroku) {
       commit_branch: commit.branch,
       commit_message: commit.message,
       commit_sha: commit.ref,
-      pipeline: pipeline.id,
+      debug: true,
+      clear_cache: !!context.flags['no-cache'],
       organization,
-      source_blob_url: sourceBlobUrl,
-      debug: true
+      pipeline: pipeline.id,
+      source_blob_url: sourceBlobUrl
     })
 
     return yield TestRun.waitForStates(['debugging', 'errored'], run, { heroku })
@@ -139,6 +140,11 @@ module.exports = {
       char: 'p',
       hasValue: true,
       description: 'pipeline'
+    },
+    {
+      name: 'no-cache',
+      hasValue: false,
+      description: 'start test run with an empty cache'
     }
   ],
   run: cli.command(co.wrap(run))

--- a/lib/heroku-api.js
+++ b/lib/heroku-api.js
@@ -18,6 +18,16 @@ function* pipelineRepository (client, pipelineID) {
   })
 }
 
+function* getDyno (client, appID, dynoID) {
+  return client.request({
+    path: `/apps/${appID}/dynos/${dynoID}`,
+    headers: {
+      Authorization: `Bearer ${client.options.token}`,
+      Accept: VERSION_HEADER
+    }
+  })
+}
+
 function* githubArchiveLink (client, user, repository, ref) {
   return client.request({
     host: KOLKRABBI,
@@ -128,6 +138,7 @@ module.exports = {
   configVars,
   createSource,
   createTestRun,
+  getDyno,
   githubArchiveLink,
   latestTestRun,
   testNodes,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,7 +21,7 @@ function * getPipeline (context, client) {
 // Deep get in an object, returning undefined if the path is invalid
 // e.g. get([{ foo: { bar: 'baz' } } ], 0, 'foo', 'bar') => 'baz'
 //
-function dig(obj, ...path) {
+function dig (obj, ...path) {
   const key = path.shift()
   if (key == null || obj == null) {
     return

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,6 +18,22 @@ function * getPipeline (context, client) {
   return pipeline
 }
 
+// Deep get in an object, returning undefined if the path is invalid
+// e.g. get([{ foo: { bar: 'baz' } } ], 0, 'foo', 'bar') => 'baz'
+//
+function dig(obj, ...path) {
+  const key = path.shift()
+  if (key == null || obj == null) {
+    return
+  }
+  const val = obj[key]
+  if (typeof val === 'object') {
+    return dig(val, ...path)
+  }
+  return val
+}
+
 module.exports = {
-  getPipeline
+  getPipeline,
+  dig
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "got": "^6.6.3",
     "heroku-cli-util": "^6.1.17",
     "heroku-pipelines": "^2.0.1",
-    "heroku-run": "^3.4.3",
+    "heroku-run": "heroku/heroku-run#16d711e10fe92a4f17d7761d57add5fdf7705197",
     "lodash.flatten": "^4.4.0",
     "shell-escape": "^0.2.0",
     "socket.io-client": "^1.5.1",

--- a/test/lib/heroku-api-test.js
+++ b/test/lib/heroku-api-test.js
@@ -37,6 +37,26 @@ describe('heroku-api', function () {
     })
   })
 
+  describe('#getDyno', function () {
+    it('returns dyno information', function* () {
+      const appID = '123-456-67-89'
+      const dynoID = '01234567-89ab-cdef-0123-456789abcdef'
+      const dyno = {
+        id: dynoID,
+        attach_url: 'rendezvous://rendezvous.runtime.heroku.com:5000/{rendezvous-id}',
+        app: { id: appID }
+      }
+
+      const api = nock(`https://api.heroku.com`)
+        .get(`/apps/${appID}/dynos/${dynoID}`)
+        .reply(200, dyno)
+
+      const response = yield herokuAPI.getDyno(new Heroku(), appID, dynoID)
+      expect(response).to.deep.eq(dyno)
+      api.done()
+    })
+  })
+
   describe('#githubArchiveLink', function () {
     it('gets a GitHub archive link', function* () {
       const { user, repository } = ['heroku', 'heroku-ci']

--- a/test/lib/utils-test.js
+++ b/test/lib/utils-test.js
@@ -37,4 +37,25 @@ describe('Utils', function () {
       api.done()
     })
   })
+
+  describe('#dig', function() {
+    it('is undefined given an undefined object', function() {
+      expect(Utils.dig(undefined)).to.be.undefined
+    });
+
+    it('deep gets into an object', function() {
+      const obj = { foo: { bar: 'baz' } }
+      expect(Utils.dig(obj, 'foo', 'bar')).to.eq('baz')
+    });
+
+    it('deep gets into an array', function() {
+      const array = [{ foo: { bar: 'baz' } }]
+      expect(Utils.dig(array, 0, 'foo', 'bar')).to.eq('baz')
+    });
+
+    it('returns undefined if the path is not present', function() {
+      const obj = { foo: { bar: 'baz' } }
+      expect(Utils.dig(obj, 'foo', 'quz')).to.be.undefined
+    });
+  });
 })

--- a/test/lib/utils-test.js
+++ b/test/lib/utils-test.js
@@ -38,24 +38,24 @@ describe('Utils', function () {
     })
   })
 
-  describe('#dig', function() {
-    it('is undefined given an undefined object', function() {
+  describe('#dig', function () {
+    it('is undefined given an undefined object', function () {
       expect(Utils.dig(undefined)).to.be.undefined
-    });
+    })
 
-    it('deep gets into an object', function() {
+    it('deep gets into an object', function () {
       const obj = { foo: { bar: 'baz' } }
       expect(Utils.dig(obj, 'foo', 'bar')).to.eq('baz')
-    });
+    })
 
-    it('deep gets into an array', function() {
+    it('deep gets into an array', function () {
       const array = [{ foo: { bar: 'baz' } }]
       expect(Utils.dig(array, 0, 'foo', 'bar')).to.eq('baz')
-    });
+    })
 
-    it('returns undefined if the path is not present', function() {
+    it('returns undefined if the path is not present', function () {
       const obj = { foo: { bar: 'baz' } }
       expect(Utils.dig(obj, 'foo', 'quz')).to.be.undefined
-    });
-  });
+    })
+  })
 })


### PR DESCRIPTION
- [x] Removes `--size` option for the `ci:debug` command
- [x] Attach to an existing dyno via test runs
- [x] Adds `--no-cache` option to start a new test run with an empty cache