### PR TITLE
Updates for new debug architecture

### DIFF
--- a/commands/ci/debug.js
+++ b/commands/ci/debug.js
@@ -65,23 +65,20 @@ function* run (context, heroku) {
   }
 
   const testNodes = yield api.testNodes(heroku, testRun.id)
-  const dynoID = Utils.dig(testNodes, 0, 'dyno', 'id')
+  const attachURL = Utils.dig(testNodes, 0, 'dyno', 'attach_url')
 
   const dyno = new Dyno({
     heroku,
     app: appSetup.app.id,
     command: 'bash',
-    'exit-code': true,
     attach: true,
     env,
     showStatus: false
   })
 
   let dynoPromise
-  if (dynoID) {
-    dyno.attach_url = (
-      yield api.getDyno(heroku, appSetup.app.id, dynoID)
-    ).attach_url
+  if (attachURL) {
+    dyno.dyno = { attach_url: attachURL }
     dynoPromise = dyno.attach()
   } else {
     dynoPromise = dyno.start()


### PR DESCRIPTION
1. We weren't setting the `dyno.attach_url` properly
2. Stop using the `exit-code` hack as it won't work in this case where we didn't set the command initially.