### PR TITLE
Update heroku ci:debug

### DIFF
--- a/commands/ci/debug.js
+++ b/commands/ci/debug.js
@@ -65,7 +65,6 @@ function* run (context, heroku) {
   }
 
   const testNodes = yield api.testNodes(heroku, testRun.id)
-  const attachURL = Utils.dig(testNodes, 0, 'dyno', 'attach_url')
 
   const dyno = new Dyno({
     heroku,
@@ -76,13 +75,7 @@ function* run (context, heroku) {
     showStatus: false
   })
 
-  let dynoPromise
-  if (attachURL) {
-    dyno.dyno = { attach_url: attachURL }
-    dynoPromise = dyno.attach()
-  } else {
-    dynoPromise = dyno.start()
-  }
+  dyno.dyno = { attach_url: Utils.dig(testNodes, 0, 'dyno', 'attach_url') }
 
   function sendSetup (data, connection) {
     if (data.toString().includes('$')) {
@@ -96,7 +89,7 @@ function* run (context, heroku) {
   }
 
   try {
-    yield dynoPromise
+    yield dyno.attach()
   } catch (err) {
     if (err.exitCode) cli.exit(err.exitCode, err)
     else throw err

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "got": "^6.6.3",
     "heroku-cli-util": "^6.1.17",
     "heroku-pipelines": "^2.0.1",
-    "heroku-run": "heroku/heroku-run#16d711e10fe92a4f17d7761d57add5fdf7705197",
+    "heroku-run": "^3.4.16",
     "lodash.flatten": "^4.4.0",
     "shell-escape": "^0.2.0",
     "socket.io-client": "^1.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -752,9 +752,9 @@ heroku-pipelines@^2.0.1:
     string-just "0.0.2"
     validator "6.2.1"
 
-heroku-run@heroku/heroku-run#16d711e10fe92a4f17d7761d57add5fdf7705197:
-  version "3.4.13"
-  resolved "https://codeload.github.com/heroku/heroku-run/tar.gz/16d711e10fe92a4f17d7761d57add5fdf7705197"
+heroku-run@^3.4.16:
+  version "3.4.16"
+  resolved "https://registry.yarnpkg.com/heroku-run/-/heroku-run-3.4.16.tgz#dddf442905c83d2bc20845d4e77559f48b500b62"
   dependencies:
     co "4.6.0"
     heroku-cli-util "^6.2.2"
@@ -1446,6 +1446,7 @@ standard-tap@^1.0.1:
   dependencies:
     concat-stream "^1.5.0"
     minimist "^1.1.2"
+    standard "^5.0.0"
     standard-json "^1.0.0"
     yamlish "0.0.7"
 


### PR DESCRIPTION
- Update to heroku-run to v3.4.16 (https://github.com/heroku/heroku-run/pull/34)
- Remove unused code. All test nodes return an `attach_url` (https://github.com/heroku/profa/pull/197)


