### PR TITLE
Add JSON output support to `heroku ci`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Command `heroku ci` && `heroku ci:list` can display JSON via the  `--json` flag.
+
 ## [1.9.3] - 2017-08-02
 
 - Command `heroku ci` && `heroku ci:list` accept pipeline name via the  `--pipelines` flag.

--- a/commands/ci/index.js
+++ b/commands/ci/index.js
@@ -5,7 +5,7 @@ const Utils = require('../../lib/utils')
 
 function* run (context, heroku) {
   const pipeline = yield Utils.getPipeline(context, heroku)
-  return yield RenderTestRuns.render(pipeline, { heroku, watch: context.flags.watch })
+  return yield RenderTestRuns.render(pipeline, { heroku, watch: context.flags.watch, json: context.flags.json })
 }
 
 const cmd = {
@@ -26,7 +26,11 @@ const cmd = {
       char: 'w',
       hasValue: false,
       description: 'keep running and watch for new and update tests'
-
+    },
+    {
+      name: 'json',
+      hasValue: false,
+      description: 'output run info in json format'
     }
   ],
   run: cli.command(co.wrap(run))

--- a/commands/ci/index.js
+++ b/commands/ci/index.js
@@ -29,6 +29,7 @@ const cmd = {
     },
     {
       name: 'json',
+      char: 'j',
       hasValue: false,
       description: 'output run info in json format'
     }

--- a/lib/render-test-runs.js
+++ b/lib/render-test-runs.js
@@ -97,12 +97,17 @@ function handleTestRunEvent (newTestRun, testRuns) {
   return testRuns
 }
 
-function * render (pipeline, { heroku, watch }) {
+function * render (pipeline, { heroku, watch, json }) {
+  let testRuns = yield api.testRuns(heroku, pipeline.id)
+
+  if(json) {
+    cli.styledJSON(testRuns)
+    return
+  }
+
   cli.styledHeader(
     `${watch ? 'Watching' : 'Showing'} latest test runs for the ${pipeline.name} pipeline`
   )
-
-  let testRuns = yield api.testRuns(heroku, pipeline.id)
 
   if (watch) {
     process.stdout.write(ansiEscapes.cursorHide)

--- a/lib/render-test-runs.js
+++ b/lib/render-test-runs.js
@@ -100,7 +100,7 @@ function handleTestRunEvent (newTestRun, testRuns) {
 function * render (pipeline, { heroku, watch, json }) {
   let testRuns = yield api.testRuns(heroku, pipeline.id)
 
-  if(json) {
+  if (json) {
     cli.styledJSON(testRuns)
     return
   }

--- a/test/commands/ci/index-test.js
+++ b/test/commands/ci/index-test.js
@@ -44,4 +44,17 @@ describe('heroku ci', function () {
 
     api.done()
   })
+
+  it('displays recent runs formatted as JSON', function* () {
+    const api = nock('https://api.heroku.com')
+      .get(`/pipelines/${pipeline.id}`)
+      .reply(200, pipeline)
+      .get(`/pipelines/${pipeline.id}/test-runs`)
+      .reply(200, runs)
+
+    yield cmd.run({ flags: { pipeline: pipeline.id, json: true } })
+
+    expect(cli.stdout).to.include('\n    "number": 123,\n')
+    api.done()
+  })
 })


### PR DESCRIPTION
---
Thanks for your contribution to heroku-ci!
---

## Checklist

The checklist enumerates the tasks you set out to do before the PR becomes ready for review

- [x] Implement feature
- [x] Write tests
- [x] Update yarn.lock
- [x] Update [CHANGELOG.md](https://github.com/heroku/heroku-ci/blob/master/CHANGELOG.md)
- [ ] Update Dev Center Docs
- [ ] Publish a new entry to [Heroku Changelog](https://devcenter.heroku.com/changelog)

## Why
Using `heroku ci` as part of a deploy pipeline requires interrogating the most recent test run to determine if it was successful. Rather than relying on arbitrary output formatting, it'd be more reliable to get this information as JSON, to be parsed with tools like `jq`.

## What are the acceptance criteria for the change?
- [ ] [DevEx](https://github.com/heroku/devex) gives a :+1:
- [ ] @person provides a :+1: that this PR yields the desired results

## How can the change be tested
- Run `heroku ci --json` against a configured pipeline
- Verify that complete output is formatted as JSON

## Demonstration
```
$ heroku ci --json
[
  {
    "actor_email": "user@example.com",
    "app_setup": {
      "id": "88fe6b96-8866-4a6e-81a6-6cbbd4cb96e4"
    },
    "clear_cache": false,
    "commit_branch": "json-output",
    "commit_message": "Show example JSON output",
    "commit_sha": "fe7812b626f0b75897077fdf42cd1ff61ecbada4",
    "created_at": "2017-08-03T12:53:39+00:00",
    "debug": false,
    "dyno": {
      "size": "performance-m"
    },
    "id": "88fe6b96-8866-4a6e-81a6-6cbbd4cb96e4",
    "message": null,
    "number": 1,
    "organization": {
      "name": "example"
    },
    "pipeline": {
      "id": "88fe6b96-8866-4a6e-81a6-6cbbd4cb96e4"
    },
    "source_blob_url": "...",
    "status": "succeeded",
    "updated_at": "2017-08-03T13:06:14+00:00",
    "user": {
      "id": "88fe6b96-8866-4a6e-81a6-6cbbd4cb96e4"
    },
    "warning_message": null
  }
]
```

## Who's Affected
Anyone wanting to interrogate build status in a more consistent way. Anywhere from 0% to 100% of users.

## Blockers & upstream dependencies
None