### PR TITLE
Improve git-related error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Changed
+
+- Improve git-related error messages
 
 ## [1.9.9] - 2018-04-18
 ### Changed


### PR DESCRIPTION
## Checklist

- [x] Implement feature
- [ ] Write tests
- [x] Update [CHANGELOG.md](https://github.com/heroku/heroku-ci/blob/master/CHANGELOG.md)
- [ ] Update Dev Center Docs
- [ ] Publish a new entry to [Heroku Changelog](https://devcenter.heroku.com/changelog)

## Why

When being in a detached HEAD state:

```
$ heroku ci:debug -a acme
 ▸    128
```

The error message is not very helpful.

## How can the change be tested

Run the following commands:

```
git checkout HEAD^0
heroku ci:debug -a acme
```

The expected output is:

```
 ▸    Please checkout a branch before running this command
```